### PR TITLE
feat(performance): max_filesize option (def: 1M) skips large files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           echo "Initializing neovim dependencies..."
           cd integration-tests/test-environment/
           # execute the lazy installation script and exit right away
-          nvim -u test-setup.lua -c "exit"
+          nvim -c "exit"
 
       # need to work around https://github.com/cypress-io/github-action/issues/1246
       - run: pnpm --filter integration-tests exec cypress install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           which rg || {
             sudo apt-get install ripgrep
           }
+          echo "Ripgrep version: $(rg --version)"
 
       - name: Run lua tests
         uses: nvim-neorocks/nvim-busted-action@v1.1.0

--- a/README.md
+++ b/README.md
@@ -50,11 +50,21 @@ return {
           ---@module "blink-ripgrep"
           ---@type blink-ripgrep.Options
           opts = {
+            -- For many options, see `rg --help` for an exact description of
+            -- the values that ripgrep expects.
+
             -- the minimum length of the current word to start searching
             -- (if the word is shorter than this, the search will not start)
             prefix_min_len = 3,
+
             -- The number of lines to show around each match in the preview window
             context_size = 5,
+
+            -- The maximum file size that ripgrep should include in its search.
+            -- Useful when your project contains large files that might cause
+            -- performance issues.
+            -- Examples: "1024" (bytes by default), "200K", "1M", "1G"
+            max_filesize = "1M",
           },
         },
       },

--- a/integration-tests/cypress.config.ts
+++ b/integration-tests/cypress.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     baseUrl: "http://localhost:3000",
     experimentalRunAllSpecs: true,
     retries: {
-      runMode: 2,
+      runMode: 5,
       openMode: 0,
     },
   },

--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -4,7 +4,8 @@
 ---@field prefix_min_len? number
 ---@field get_command? fun(context: blink.cmp.Context, prefix: string): string[] # Changing this might break things - if you need some customization, please open and issue 🙂
 ---@field get_prefix? fun(context: blink.cmp.Context): string
----@field context_size? number "The number of lines to show around each match"
+---@field context_size? number # The number of lines to show around each match
+---@field max_filesize? number # The maximum file size that ripgrep should include in its search. Examples: "1024" (bytes by default), "200K", "1M", "1G"
 
 ---@class blink-ripgrep.RgSource : blink.cmp.Source
 ---@field prefix_min_len number
@@ -58,6 +59,7 @@ function RgSource.new(opts)
         "--json",
         "--context=" .. (opts.context_size or 5),
         "--word-regexp",
+        "--max-filesize=" .. (opts.max_filesize or "1M"),
         "--ignore-case",
         "--",
         prefix .. "[\\w_-]+",


### PR DESCRIPTION
By default, ripgrep will search all files in the project, which can be slow if there are large files. Now, files larger than 1 megabyte are skipped from the search altogether by default. This can be customized with the `max_filesize` option in the `blink-ripgrep` configuration.

The possible values are determined by ripgrep itself. Examples:

- "1024" (bytes by default)
- "200K"
- "1M"
- "999G" (effectively opts out of ignoring any files)