### PR TITLE
perf: only register each unique match once

### DIFF
--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -102,20 +102,26 @@ function RgSource:get_completions(context, resolve)
     local items = {}
     for _, file in pairs(parsed.files) do
       for _, match in ipairs(file.submatches) do
-        local label = match.match.text .. " (rg)"
-        -- the implementation for render_detail_and_documentation:
-        -- ../../integration-tests/test-environment/.repro/data/nvim/lazy/blink.cmp/lua/blink/cmp/windows/lib/docs.lua
-        ---@diagnostic disable-next-line: missing-fields
-        items[match.match.text] = {
-          documentation = {
-            kind = "markdown",
-            value = table.concat(file.lines, "\n"),
-          },
-          detail = file.relative_to_cwd,
-          source_id = "blink-ripgrep",
-          label = label,
-          insertText = match.match.text,
-        }
+        local matchkey = match.match.text
+
+        -- PERF: only register the match once - right now there is no useful
+        -- way to display the same match multiple times
+        if not items[matchkey] then
+          local label = match.match.text .. " (rg)"
+          -- the implementation for render_detail_and_documentation:
+          -- ../../integration-tests/test-environment/.repro/data/nvim/lazy/blink.cmp/lua/blink/cmp/windows/lib/docs.lua
+          ---@diagnostic disable-next-line: missing-fields
+          items[matchkey] = {
+            documentation = {
+              kind = "markdown",
+              value = table.concat(file.lines, "\n"),
+            },
+            detail = file.relative_to_cwd,
+            source_id = "blink-ripgrep",
+            label = label,
+            insertText = matchkey,
+          }
+        end
       end
     end
 


### PR DESCRIPTION
Right now we are registering each match multiple times, which is not very useful. It will add more context to the context window (documentation), but it's not very clear to read the context anyway. Most of the time I just ignore it.

If in the future we have a better way to inspect each submatch, this should be reconsidered.