### PR TITLE
perf: only collect the necessary context preview for each match

### DIFF
--- a/lua/blink-ripgrep/ripgrep_parser.lua
+++ b/lua/blink-ripgrep/ripgrep_parser.lua
@@ -4,22 +4,39 @@ local M = {}
 ---@field files table<string, RipgrepFile>
 
 ---@class RipgrepFile
----@field lines string[] the context preview for all the matches
----@field submatches RipgrepSubmatch[] the matches
+---@field language string the treesitter language of the file, used to determine what grammar to highlight the preview with
+---@field lines table<number, string> the context preview, shared for all the matches in this file so that they can display a subset
+---@field matches RipgrepMatch[]
 ---@field relative_to_cwd string the relative path of the file to the current working directory
 
----@class RipgrepSubmatch
----@field start number the start column of the match
----@field end_ number the end column of the match
+---@class RipgrepMatch
+---@field line_number number
+---@field start_col number
+---@field end_col number
 ---@field match {text: string} the matched text
+---@field context_preview string[] the preview of this specific match
+
+---@param json unknown
+---@param output RipgrepOutput
+local function get_file_context(json, output)
+  ---@type string
+  local filename = json.data.path.text
+  local file = output.files[filename]
+  local line_number = json.data.line_number
+  -- assert(line_number)
+  -- assert(not file.lines[line_number])
+
+  return file, line_number
+end
 
 ---@param ripgrep_output string[] ripgrep output in jsonl format
 ---@param cwd string the current working directory
-function M.parse(ripgrep_output, cwd)
+---@param context_size number the number of lines of context to include in the output
+function M.parse(ripgrep_output, cwd, context_size)
   ---@type RipgrepOutput
   local output = { files = {} }
 
-  -- phase one: parse the output and collect the matches and context
+  -- parse the output and collect the matches and context
   for _, line in ipairs(ripgrep_output) do
     local ok, json = pcall(vim.json.decode, line)
     if ok then
@@ -27,41 +44,72 @@ function M.parse(ripgrep_output, cwd)
         ---@type string
         local filename = json.data.path.text
 
-        local filetype = vim.fn.fnamemodify(filename, ":e")
-        local lang = vim.treesitter.language.get_lang(filetype or "text")
-          or "markdown"
-
         local relative_filename = filename
         if filename:sub(1, #cwd) == cwd then
           relative_filename = filename:sub(#cwd + 2)
         end
+
+        local filetype = vim.fn.fnamemodify(filename, ":e")
+        local language = vim.treesitter.language.get_lang(filetype or "text")
+          or "markdown"
+
         output.files[filename] = {
-          lines = { "```" .. lang },
-          submatches = {},
+          language = language,
+          lines = {},
+          matches = {},
           relative_to_cwd = relative_filename,
         }
       elseif json.type == "context" then
-        ---@type string
-        local filename = json.data.path.text
-        local data = output.files[filename]
-
-        data.lines[#data.lines + 1] = json.data.lines.text
+        local file, line_number = get_file_context(json, output)
+        file.lines[line_number] = json.data.lines.text
       elseif json.type == "match" then
-        ---@type string
-        local filename = json.data.path.text
-        local data = output.files[filename]
+        local file, line_number = get_file_context(json, output)
+        file.lines[line_number] = json.data.lines.text
 
-        data.lines[#data.lines + 1] = json.data.lines.text
-
-        data.submatches[#data.submatches + 1] = {
-          start = json.data.submatches[1].start,
-          end_ = json.data.submatches[1]["end"],
+        file.matches[#file.matches + 1] = {
+          start_col = json.data.submatches[1].start,
+          end_col = json.data.submatches[1]["end"],
           match = { text = json.data.submatches[1].match.text },
+          line_number = line_number,
+          context_preview = {},
         }
+      elseif json.type == "end" then
+        -- Right now, we have collected the necessary lines for the context in
+        -- previous steps. Get the context preview for each match.
+        local filename = json.data.path.text
+        local file = output.files[filename]
+
+        for _, match in ipairs(file.matches) do
+          match.context_preview =
+            M.get_context_preview(file.lines, match.line_number, context_size)
+        end
+
+        -- clear the lines to save memory
+        file.lines = {}
       end
     end
   end
   return output
+end
+
+---@param lines table<number, string>
+---@param matched_line number the line number the match was found on
+---@param context_size number how many lines of context to include before and after the match
+function M.get_context_preview(lines, matched_line, context_size)
+  ---@type string[]
+  local context_preview = {}
+
+  local start_line = matched_line - context_size
+  local end_line = matched_line + context_size
+
+  for i = start_line, end_line do
+    local line = lines[i]
+    if line then
+      context_preview[#context_preview + 1] = lines[i]
+    end
+  end
+
+  return context_preview
 end
 
 return M

--- a/package.json
+++ b/package.json
@@ -15,5 +15,5 @@
     "prettier": "3.3.3",
     "prettier-plugin-packagejson": "2.5.3"
   },
-  "packageManager": "pnpm@9.12.1+sha256.91452fdfa46234ae447d46d5c4fc4e7e0a7058f90495c4b6f77f8beebbb154e3"
+  "packageManager": "pnpm@9.14.4+sha256.26a726b633b629a3fabda006f696ae4260954a3632c8054112d7ae89779e5f9a"
 }

--- a/spec/blink-ripgrep/ripgrep_parser_spec.lua
+++ b/spec/blink-ripgrep/ripgrep_parser_spec.lua
@@ -6,19 +6,96 @@ describe("ripgrep_parser", function()
     vim.fn.readfile("spec/blink-ripgrep/rg-output.jsonl")
 
   it("can parse according to the expected schema", function()
-    local result = ripgrep_parser.parse(ripgrep_output_lines, "/home/user")
+    local result = ripgrep_parser.parse(ripgrep_output_lines, "/home/user", 1)
     local filename = "integration-tests/cypress/e2e/cmp-rg/basic_spec.cy.ts"
 
     assert.is_not_nil(result.files)
     assert.is_not_nil(result.files[filename])
-    assert.is_truthy(#result.files[filename].lines > 19)
-    assert.same(#result.files[filename].submatches, 3)
+    assert.is_truthy(#result.files[filename].lines == 0)
+    assert.same(#result.files[filename].matches, 3)
     assert.same(result.files[filename].relative_to_cwd, filename)
 
-    for _, submatch in ipairs(result.files[filename].submatches) do
-      assert.is_not_nil(submatch.start)
-      assert.is_not_nil(submatch.end_)
-      assert.is_not_nil(submatch.match.text)
+    for _, file in ipairs(result.files) do
+      assert.is_not_nil(file.language)
     end
+
+    for _, submatch in ipairs(result.files[filename].matches) do
+      assert.is_not_nil(submatch.match.text)
+      assert.is_not_nil(submatch.context_preview)
+      assert.is_not_nil(submatch.line_number)
+      assert.is_not_nil(submatch.start_col)
+      assert.is_not_nil(submatch.end_col)
+    end
+  end)
+
+  describe("get_context_preview", function()
+    it("can display context around the match", function()
+      -- the happy path case
+      local lines = {
+        [1] = "line 1",
+        [2] = "line 2",
+        [3] = "line 3",
+        [4] = "line 4",
+        [5] = "line 5",
+        [6] = "line 6",
+        [7] = "line 7",
+        [8] = "line 8",
+        [9] = "line 9",
+        [10] = "line 10",
+      }
+
+      local matched_line = 4
+      local context_size = 1
+      local result =
+        ripgrep_parser.get_context_preview(lines, matched_line, context_size)
+
+      assert.same(result, {
+        "line 3",
+        "line 4",
+        "line 5",
+      })
+    end)
+
+    it("does not crash if context_size is too large", function()
+      local lines = { "line 1" }
+
+      local matched_line = 1
+      local context_size = 10
+      local result =
+        ripgrep_parser.get_context_preview(lines, matched_line, context_size)
+
+      assert.same(result, lines)
+    end)
+
+    it("does not crash if context_size is too small", function()
+      local lines = { "line 1" }
+
+      local matched_line = 1
+      local context_size = 0
+      local result =
+        ripgrep_parser.get_context_preview(lines, matched_line, context_size)
+
+      assert.same(result, lines)
+    end)
+
+    it("can display context around the match at the end of the file", function()
+      local lines = {
+        [7] = "line 7",
+        [8] = "line 8",
+        [9] = "line 9",
+        [10] = "line 10",
+      }
+
+      local matched_line = 9
+      local context_size = 1
+      local result =
+        ripgrep_parser.get_context_preview(lines, matched_line, context_size)
+
+      assert.same(result, {
+        "line 8",
+        "line 9",
+        "line 10",
+      })
+    end)
   end)
 end)


### PR DESCRIPTION
Issue
=====

The current implementation of the ripgrep parser includes all the lines that matched in each file, and displays the same lines for each match. As a user, I'm interested in the context around the match, not the entire file. This is especially important when the file is large, and the file contains a lot of matches.

Lots of unnecessary work is being done in this case.

Solution
========

Only include the necessary context preview for each match. This will reduce the memory usage and hopefully make the plugin faster.

The speed could still be better in huge repos, but this is a step in the right direction.