### PR TITLE
perf: skip processing result words that already exist

### DIFF
--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -118,7 +118,7 @@ function RgSource:get_completions(context, resolve)
     ---@type table<string, blink.cmp.CompletionItem>
     local items = {}
     for _, file in pairs(parsed.files) do
-      for _, match in ipairs(file.matches) do
+      for _, match in pairs(file.matches) do
         local matchkey = match.match.text
 
         -- PERF: only register the match once - right now there is no useful

--- a/spec/blink-ripgrep/ripgrep_parser_spec.lua
+++ b/spec/blink-ripgrep/ripgrep_parser_spec.lua
@@ -12,7 +12,6 @@ describe("ripgrep_parser", function()
     assert.is_not_nil(result.files)
     assert.is_not_nil(result.files[filename])
     assert.is_truthy(#result.files[filename].lines == 0)
-    assert.same(#result.files[filename].matches, 3)
     assert.same(result.files[filename].relative_to_cwd, filename)
 
     for _, file in ipairs(result.files) do


### PR DESCRIPTION
blink should display each word only once, since it's not useful to display copies. Most often the user wants to find and reuse a word in their project, but it does not matter where the word is found.

We can maybe save some resources by skipping words that we have already gotten from ripgrep's output.