### PR TITLE
feat: fall back to regex highlighting when treesitter not available

### DIFF
--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -52,6 +52,12 @@ export const MyTestDirectorySchema = z.object({
           name: z.literal("subproject/"),
           type: z.literal("directory"),
           contents: z.object({
+            "example.clj": z.object({
+              name: z.literal("example.clj"),
+              type: z.literal("file"),
+              extension: z.literal("clj"),
+              stem: z.literal("example."),
+            }),
             "file1.lua": z.object({
               name: z.literal("file1.lua"),
               type: z.literal("file"),
@@ -91,6 +97,7 @@ export const testDirectoryFiles = z.enum([
   ".config",
   "initial-file.txt",
   "limited/main-project-file.lua",
+  "limited/subproject/example.clj",
   "limited/subproject/file1.lua",
   "limited/subproject/file2.lua",
   "limited/subproject",

--- a/integration-tests/cypress/e2e/blink-ripgrep/basic_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/basic_spec.cy.ts
@@ -81,6 +81,36 @@ describe("searching inside projects", () => {
       )
     })
   })
+
+  describe("syntax highlighting", () => {
+    it("can highlight file types that don't have a treesitter parser installed", () => {
+      cy.visit("/")
+      cy.startNeovim({ filename: "limited/subproject/file1.lua" }).then(() => {
+        // when opening a file from a subproject, the search should be limited to
+        // the nearest .git directory (only the files in the same project should
+        // be searched)
+        cy.contains("This is text from file1.lua")
+        createFakeGitDirectoriesToLimitRipgrepScope()
+
+        cy.typeIntoTerminal("o")
+        // match text inside ../../../test-environment/limited/subproject/example.clj
+        cy.typeIntoTerminal("Subtraction")
+
+        // make sure the syntax is highlighted
+        // (needs https://github.com/Saghen/blink.cmp/pull/462)
+        cy.contains("defn").should(
+          "have.css",
+          "color",
+          rgbify(flavors.macchiato.colors.pink.rgb),
+        )
+        cy.contains("Clojure Calculator").should(
+          "have.css",
+          "color",
+          rgbify(flavors.macchiato.colors.green.rgb),
+        )
+      })
+    })
+  })
 })
 
 function createFakeGitDirectoriesToLimitRipgrepScope() {

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -34,6 +34,7 @@ vim.o.swapfile = false
 local plugins = {
   {
     "saghen/blink.cmp",
+    dir = "/Users/mikavilpas/git/blink.cmp/",
     event = "VeryLazy",
     -- use a release tag to download pre-built binaries
     version = "v0.*",

--- a/integration-tests/test-environment/limited/subproject/example.clj
+++ b/integration-tests/test-environment/limited/subproject/example.clj
@@ -1,0 +1,23 @@
+(ns calculator.core)
+
+(defn add [a b]
+  (+ a b))
+
+(defn subtract [a b]
+  (- a b))
+
+(defn multiply [a b]
+  (* a b))
+
+(defn divide [a b]
+  (if (zero? b)
+    "Cannot divide by zero!"
+    (/ a b)))
+
+(defn -main []
+  (println "Welcome to the Clojure Calculator!")
+  (println "Addition: 10 + 5 =" (add 10 5))
+  (println "Subtraction: 10 - 5 =" (subtract 10 5))
+  (println "Multiplication: 10 * 5 =" (multiply 10 5))
+  (println "Division: 10 / 5 =" (divide 10 5))
+  (println "Division: 10 / 0 =" (divide 10 0)))

--- a/lua/blink-ripgrep/ripgrep_parser.lua
+++ b/lua/blink-ripgrep/ripgrep_parser.lua
@@ -49,9 +49,12 @@ function M.parse(ripgrep_output, cwd, context_size)
           relative_filename = filename:sub(#cwd + 2)
         end
 
-        local filetype = vim.fn.fnamemodify(filename, ":e")
-        local language = vim.treesitter.language.get_lang(filetype or "text")
-          or "markdown"
+        local ext = vim.fn.fnamemodify(filename, ":e")
+
+        local ft = vim.filetype.match({ filename = filename })
+        local language = ft
+          or vim.treesitter.language.get_lang(ext or "text")
+          or ext
 
         output.files[filename] = {
           language = language,


### PR DESCRIPTION
Right now this also needs support from blink. See here:

https://github.com/Saghen/blink.cmp/pull/462