### PR TITLE
fix: crash when no options are provided

### DIFF
--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -55,9 +55,10 @@ local plugins = {
             module = "blink-ripgrep",
             name = "Ripgrep",
             ---@type blink-ripgrep.Options
-            opts = {
-              --
-            },
+            -- opts = {
+            --   Keep the default options empty for tests, so that the we can
+            --   make sure they are supported without specifying them
+            -- },
           },
         },
       },


### PR DESCRIPTION
Solves https://github.com/mikavilpas/blink-ripgrep.nvim/issues/52