### PR TITLE
feat: allow passing `additional_rg_options` to ripgrep

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ return {
             -- performance issues.
             -- Examples: "1024" (bytes by default), "200K", "1M", "1G"
             max_filesize = "1M",
+
+            -- (advanced) Any additional options you want to give to ripgrep.
+            -- See `rg -h` for a list of all available options. Might be
+            -- helpful in adjusting performance in specific situations.
+            -- If you have an idea for a default, please open an issue!
+            --
+            -- Not everything will work (obviously).
+            additional_rg_options = {}
           },
         },
       },

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -32,6 +32,18 @@ export const MyTestDirectorySchema = z.object({
         }),
       }),
     }),
+    "config-modifications": z.object({
+      name: z.literal("config-modifications/"),
+      type: z.literal("directory"),
+      contents: z.object({
+        ".gitkeep": z.object({
+          name: z.literal(".gitkeep"),
+          type: z.literal("file"),
+          extension: z.literal(""),
+          stem: z.literal(".gitkeep"),
+        }),
+      }),
+    }),
     "initial-file.txt": z.object({
       name: z.literal("initial-file.txt"),
       type: z.literal("file"),
@@ -95,6 +107,8 @@ export const testDirectoryFiles = z.enum([
   ".config/nvim/init.lua",
   ".config/nvim",
   ".config",
+  "config-modifications/.gitkeep",
+  "config-modifications",
   "initial-file.txt",
   "limited/main-project-file.lua",
   "limited/subproject/file1.lua",

--- a/spec/blink-ripgrep/get_command_spec.lua
+++ b/spec/blink-ripgrep/get_command_spec.lua
@@ -1,0 +1,28 @@
+local assert = require("luassert")
+local blink_ripgrep = require("blink-ripgrep")
+
+describe("get_command", function()
+  it("allows passing additional_rg_options", function()
+    local plugin = blink_ripgrep.new({
+      additional_rg_options = { "--foo", "--bar" },
+    })
+    local cmd = plugin.get_command({}, "hello")
+
+    -- don't compare the last item (the directory) as that changes depending on
+    -- the test environment (such as individual developers' machines or ci)
+    table.remove(cmd)
+    assert.are_same(cmd, {
+      "rg",
+      "--no-config",
+      "--json",
+      "--context=5",
+      "--word-regexp",
+      "--max-filesize=1M",
+      "--ignore-case",
+      "--foo",
+      "--bar",
+      "--",
+      "hello[\\w_-]+",
+    })
+  end)
+end)


### PR DESCRIPTION
This can help in adjusting performance in specific situations. A "batteries included" experience is provided by default, but specific situations might benefit from additional options.