### PR TITLE
fix: random blink crash due to E5560 (fast event context)

### DIFF
--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -157,12 +157,14 @@ function RgSource:get_completions(context, resolve)
       end
     end
 
-    resolve({
-      is_incomplete_forward = false,
-      is_incomplete_backward = false,
-      items = vim.tbl_values(items),
-      context = context,
-    })
+    vim.schedule(function()
+      resolve({
+        is_incomplete_forward = false,
+        is_incomplete_backward = false,
+        items = vim.tbl_values(items),
+        context = context,
+      })
+    end)
   end)
 end
 

--- a/package.json
+++ b/package.json
@@ -15,5 +15,5 @@
     "prettier": "3.3.3",
     "prettier-plugin-packagejson": "2.5.3"
   },
-  "packageManager": "pnpm@9.14.4+sha256.26a726b633b629a3fabda006f696ae4260954a3632c8054112d7ae89779e5f9a"
+  "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
 }


### PR DESCRIPTION
Fixes https://github.com/mikavilpas/blink-ripgrep.nvim/issues/53