### PR TITLE
feat: fall back to regex highlighting when treesitter not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ return {
             --
             -- Not everything will work (obviously).
             additional_rg_options = {},
+
+            -- When a result is found for a file whose filetype does not have a
+            -- treesitter parser installed, fall back to regex based highlighting
+            -- that is bundled in Neovim.
+            fallback_to_regex_highlighting = true,
           },
         },
       },

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -76,6 +76,12 @@ export const MyTestDirectorySchema = z.object({
           name: z.literal("subproject/"),
           type: z.literal("directory"),
           contents: z.object({
+            "example.clj": z.object({
+              name: z.literal("example.clj"),
+              type: z.literal("file"),
+              extension: z.literal("clj"),
+              stem: z.literal("example."),
+            }),
             "file1.lua": z.object({
               name: z.literal("file1.lua"),
               type: z.literal("file"),
@@ -131,6 +137,7 @@ export const testDirectoryFiles = z.enum([
   "config-modifications",
   "initial-file.txt",
   "limited/main-project-file.lua",
+  "limited/subproject/example.clj",
   "limited/subproject/file1.lua",
   "limited/subproject/file2.lua",
   "limited/subproject/file3.lua",

--- a/integration-tests/cypress/e2e/blink-ripgrep/basic_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/basic_spec.cy.ts
@@ -182,6 +182,36 @@ describe("searching inside projects", () => {
       })
     })
   })
+
+  describe("syntax highlighting", () => {
+    it("can highlight file types that don't have a treesitter parser installed", () => {
+      cy.visit("/")
+      cy.startNeovim({ filename: "limited/subproject/file1.lua" }).then(() => {
+        // when opening a file from a subproject, the search should be limited to
+        // the nearest .git directory (only the files in the same project should
+        // be searched)
+        cy.contains("This is text from file1.lua")
+        createFakeGitDirectoriesToLimitRipgrepScope()
+
+        cy.typeIntoTerminal("o")
+        // match text inside ../../../test-environment/limited/subproject/example.clj
+        cy.typeIntoTerminal("Subtraction")
+
+        // make sure the syntax is highlighted
+        // (needs https://github.com/Saghen/blink.cmp/pull/462)
+        cy.contains("defn").should(
+          "have.css",
+          "color",
+          rgbify(flavors.macchiato.colors.pink.rgb),
+        )
+        cy.contains("Clojure Calculator").should(
+          "have.css",
+          "color",
+          rgbify(flavors.macchiato.colors.green.rgb),
+        )
+      })
+    })
+  })
 })
 
 function createFakeGitDirectoriesToLimitRipgrepScope() {

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -34,6 +34,8 @@ vim.o.swapfile = false
 local plugins = {
   {
     "saghen/blink.cmp",
+    -- dir = "/Users/mikavilpas/git/blink.cmp/",
+
     event = "VeryLazy",
     -- use a release tag to download pre-built binaries
     -- https://github.com/Saghen/blink.cmp/releases
@@ -41,6 +43,8 @@ local plugins = {
 
     -- to (locally) track nightly builds, use the following:
     -- version = false,
+
+    -- to (locally) track nightly builds, use the following:
     -- dir = "/Users/mikavilpas/git/blink.cmp/",
     -- build = "cargo build --release",
 
@@ -64,11 +68,6 @@ local plugins = {
           },
         },
       },
-
-      -- 2024-11-28 configuration for the nightly version of blink. mikavilpas
-      -- uses this for local development, but currently ci uses the stable
-      -- version
-      --
       ---@diagnostic disable-next-line: missing-fields
       completion = {
         ---@diagnostic disable-next-line: missing-fields

--- a/integration-tests/test-environment/limited/subproject/example.clj
+++ b/integration-tests/test-environment/limited/subproject/example.clj
@@ -1,0 +1,23 @@
+(ns calculator.core)
+
+(defn add [a b]
+  (+ a b))
+
+(defn subtract [a b]
+  (- a b))
+
+(defn multiply [a b]
+  (* a b))
+
+(defn divide [a b]
+  (if (zero? b)
+    "Cannot divide by zero!"
+    (/ a b)))
+
+(defn -main []
+  (println "Welcome to the Clojure Calculator!")
+  (println "Addition: 10 + 5 =" (add 10 5))
+  (println "Subtraction: 10 - 5 =" (subtract 10 5))
+  (println "Multiplication: 10 * 5 =" (multiply 10 5))
+  (println "Division: 10 / 5 =" (divide 10 5))
+  (println "Division: 10 / 0 =" (divide 10 0)))


### PR DESCRIPTION
When a result is found for a file whose filetype does not have a
treesitter parser installed, fall back to regex based highlighting that
is bundled in Neovim. This allows highlighting many more file types out
of the box.

See here for the blink side implementation and a mini demo:

https://github.com/Saghen/blink.cmp/pull/650