### PR TITLE
feat: allow flexible configuration of the project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ as repetitive typing.
 
 > [!NOTE]
 >
-> A project root is considered to be the nearest ancestor directory containing a
-> `.git` directory. If none can be found, Neovim's current working directory is
-> used.
+> By default, a project root is considered to be the nearest ancestor directory
+> containing a `.git` directory. This can be configured with the
+> `project_root_marker` option.
 
 ![blink-ripgrep search with a context preview](./demo/screenshot.png)
 
@@ -75,6 +75,12 @@ return {
             -- "1024" (bytes by default), "200K", "1M", "1G", which will
             -- exclude files larger than that size.
             max_filesize = "1M",
+
+            -- Specifies how to find the root of the project where the ripgrep
+            -- search will start from. Accepts the same options as the marker
+            -- given to `:h vim.fs.root()` which offers many possibilities for
+            -- configuration.
+            project_root_marker = ".git",
 
             -- The casing to use for the search in a format that ripgrep
             -- accepts. Defaults to "--ignore-case". See `rg --help` for all the

--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -9,6 +9,7 @@
 ---@field search_casing? string # The casing to use for the search in a format that ripgrep accepts. Defaults to "--ignore-case". See `rg --help` for all the available options ripgrep supports, but you can try "--case-sensitive" or "--smart-case".
 ---@field additional_rg_options? string[] # (advanced) Any options you want to give to ripgrep. See `rg -h` for a list of all available options.
 ---@field fallback_to_regex_highlighting? boolean # (default: true) When a result is found for a file whose filetype does not have a treesitter parser installed, fall back to regex based highlighting that is bundled in Neovim.
+---@field project_root_marker? unknown # Specifies how to find the root of the project where the ripgrep search will start from. Accepts the same options as the marker given to `:h vim.fs.root()` which offers many possibilities for configuration. Defaults to ".git".
 
 ---@class blink-ripgrep.RgSource : blink.cmp.Source
 ---@field get_command fun(context: blink.cmp.Context, prefix: string): string[]
@@ -46,6 +47,7 @@ RgSource.config = {
   additional_rg_options = {},
   search_casing = "--ignore-case",
   fallback_to_regex_highlighting = true,
+  project_root_marker = ".git",
 }
 
 -- set up default options so that they are used by the next search
@@ -102,7 +104,9 @@ function RgSource.new(input_opts)
         prefix .. "[\\w_-]+",
         -- NOTE: 2024-11-28 the logic is documented in the README file, and
         -- should be kept up to date
-        vim.fn.fnameescape(vim.fs.root(0, ".git") or vim.fn.getcwd()),
+        vim.fn.fnameescape(
+          vim.fs.root(0, RgSource.config.project_root_marker) or vim.fn.getcwd()
+        ),
       }
       for _, option in ipairs(final) do
         table.insert(cmd, option)

--- a/spec/blink-ripgrep/get_command_spec.lua
+++ b/spec/blink-ripgrep/get_command_spec.lua
@@ -2,10 +2,17 @@ local assert = require("luassert")
 local blink_ripgrep = require("blink-ripgrep")
 
 describe("get_command", function()
+  local default_config = vim.tbl_deep_extend("error", {}, blink_ripgrep.config)
+
+  before_each(function()
+    blink_ripgrep.config = default_config
+  end)
+
   it("allows passing additional_rg_options", function()
     local plugin = blink_ripgrep.new({
       additional_rg_options = { "--foo", "--bar" },
     })
+    ---@diagnostic disable-next-line: missing-fields
     local cmd = plugin.get_command({}, "hello")
 
     -- don't compare the last item (the directory) as that changes depending on
@@ -21,6 +28,63 @@ describe("get_command", function()
       "--ignore-case",
       "--foo",
       "--bar",
+      "--",
+      "hello[\\w_-]+",
+    })
+  end)
+
+  it("allows configuring the context size", function()
+    local plugin = blink_ripgrep.new({ context_size = 9 })
+    ---@diagnostic disable-next-line: missing-fields
+    local cmd = plugin.get_command({}, "hello")
+
+    table.remove(cmd)
+    assert.are_same(cmd, {
+      "rg",
+      "--no-config",
+      "--json",
+      "--context=9",
+      "--word-regexp",
+      "--max-filesize=1M",
+      "--ignore-case",
+      "--",
+      "hello[\\w_-]+",
+    })
+  end)
+
+  it("allows configuring the max_filesize", function()
+    local plugin = blink_ripgrep.new({ max_filesize = "2M" })
+    ---@diagnostic disable-next-line: missing-fields
+    local cmd = plugin.get_command({}, "hello")
+
+    table.remove(cmd)
+    assert.are_same(cmd, {
+      "rg",
+      "--no-config",
+      "--json",
+      "--context=5",
+      "--word-regexp",
+      "--max-filesize=2M",
+      "--ignore-case",
+      "--",
+      "hello[\\w_-]+",
+    })
+  end)
+
+  it("allows configuring the casing", function()
+    local plugin = blink_ripgrep.new({ search_casing = "--smart-case" })
+    ---@diagnostic disable-next-line: missing-fields
+    local cmd = plugin.get_command({}, "hello")
+
+    table.remove(cmd)
+    assert.are_same(cmd, {
+      "rg",
+      "--no-config",
+      "--json",
+      "--context=5",
+      "--word-regexp",
+      "--max-filesize=1M",
+      "--smart-case",
       "--",
       "hello[\\w_-]+",
     })


### PR DESCRIPTION
Previously, the project root was always assumed to be the nearest directory containing a `.git` directory. This commit introduces a new `project_root_marker` option that allows users to configure how the project root is found.

This option accepts the same arguments as the marker given to `:h vim.fs.root()` which offers many possibilities for configuration. The default value is still `.git`.

Closes #59 