### PR TITLE
feat: highlight the match in the documentation window

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ return {
         },
       },
       keymap = {
+        -- 👇🏻👇🏻 (optional) add a keymap to invoke the search manually
         ["<c-g>"] = {
           function()
             -- invoke manually, requires blink >v0.8.0

--- a/integration-tests/cypress/e2e/blink-ripgrep/basic_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/basic_spec.cy.ts
@@ -25,7 +25,7 @@ describe("the basics", () => {
       // should show the text for the matched line
       //
       // the text should also be syntax highlighted
-      cy.contains("Hippopotamus234 was my previous password").should(
+      cy.contains("was my previous password").should(
         "have.css",
         "color",
         rgbify(flavors.macchiato.colors.green.rgb),
@@ -122,7 +122,7 @@ describe("searching inside projects", () => {
       cy.typeIntoTerminal("o")
       cy.typeIntoTerminal("some")
 
-      cy.contains("someTextFromFile2 here").should(
+      cy.contains("here").should(
         "have.css",
         "color",
         rgbify(flavors.macchiato.colors.green.rgb),
@@ -142,7 +142,7 @@ describe("searching inside projects", () => {
       cy.typeIntoTerminal("o")
       cy.typeIntoTerminal("some")
 
-      cy.contains("someTextFromFile2 here").should(
+      cy.contains("here").should(
         "have.css",
         "color",
         rgbify(flavors.macchiato.colors.green.rgb),
@@ -183,7 +183,37 @@ describe("searching inside projects", () => {
     })
   })
 
-  describe("syntax highlighting", () => {
+  it("can highlight the match in the documentation window", () => {
+    cy.visit("/")
+    cy.startNeovim({ filename: "limited/subproject/file1.lua" }).then(() => {
+      // When a match has been found in a file in the project, the
+      // documentation window should show a preview of the match context (lines
+      // around the match), and highlight the part where the match was found.
+      // This way the user can quickly get an idea of where the match was
+      // found.
+      cy.contains("This is text from file1.lua")
+      createFakeGitDirectoriesToLimitRipgrepScope()
+
+      cy.typeIntoTerminal("o")
+      // match text inside ../../../test-environment/limited/subproject/example.clj
+      cy.typeIntoTerminal("Subtraction")
+
+      // we should see the match highlighted with the configured color
+      // somewhere on the page (in the documentation window)
+      cy.get("span")
+        .filter((_, el) => el.textContent?.includes("Subtraction") ?? false)
+        .then((elements) => {
+          const matchingElements = elements.map((_, el) => {
+            return window.getComputedStyle(el).backgroundColor
+          })
+
+          return matchingElements.toArray()
+        })
+        .should("contain", rgbify(flavors.macchiato.colors.mauve.rgb))
+    })
+  })
+
+  describe("regex based syntax highlighting", () => {
     it("can highlight file types that don't have a treesitter parser installed", () => {
       cy.visit("/")
       cy.startNeovim({ filename: "limited/subproject/file1.lua" }).then(() => {

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -97,7 +97,17 @@ local plugins = {
     "mikavilpas/blink-ripgrep.nvim",
     -- for tests, always use the code from this repository
     dir = "../..",
+    config = function()
+      -- customize the search highlighting (Search)
+      local colors = require("catppuccin.palettes.macchiato")
+      vim.api.nvim_set_hl(
+        0,
+        "BlinkRipgrepMatch",
+        { fg = colors.base, bg = colors.mauve }
+      )
+    end,
   },
+
   { "catppuccin/nvim", name = "catppuccin", priority = 1000 },
 }
 require("lazy").setup({ spec = plugins })

--- a/lua/blink-ripgrep/highlighting.lua
+++ b/lua/blink-ripgrep/highlighting.lua
@@ -1,0 +1,30 @@
+local M = {}
+
+---@param bufnr number
+---@param match blink-ripgrep.RipgrepMatch
+---@param highlight_ns_id number
+function M.highlight_match_in_doc_window(bufnr, match, highlight_ns_id)
+  ---@type number | nil
+  local line_in_docs = nil
+  for line, data in ipairs(match.context_preview) do
+    if data.line_number == match.line_number then
+      line_in_docs = line
+      break
+    end
+  end
+
+  assert(line_in_docs, "missing line in docs")
+
+  vim.api.nvim_buf_set_extmark(
+    bufnr,
+    highlight_ns_id,
+    line_in_docs + 1,
+    match.start_col,
+    {
+      end_col = match.end_col,
+      hl_group = "BlinkRipgrepMatch",
+    }
+  )
+end
+
+return M

--- a/lua/blink-ripgrep/ripgrep_parser.lua
+++ b/lua/blink-ripgrep/ripgrep_parser.lua
@@ -14,7 +14,7 @@ local M = {}
 ---@field start_col number
 ---@field end_col number
 ---@field match {text: string} the matched text
----@field context_preview string[] the preview of this match
+---@field context_preview blink-ripgrep.NumberedLine[] the preview of this match. Each key is the line number in the original file, and each value is the line of context (text)
 
 ---@param json unknown
 ---@param output blink-ripgrep.RipgrepOutput
@@ -104,20 +104,25 @@ function M.parse(ripgrep_output, cwd, context_size)
   return output
 end
 
+---@alias blink-ripgrep.NumberedLine {line_number: number, text: string}
+
 ---@param lines table<number, string>
 ---@param matched_line number the line number the match was found on
 ---@param context_size number how many lines of context to include before and after the match
+---@return blink-ripgrep.NumberedLine[]
 function M.get_context_preview(lines, matched_line, context_size)
-  ---@type string[]
+  ---@type blink-ripgrep.NumberedLine[]
   local context_preview = {}
 
-  local start_line = matched_line - context_size
+  local start_line = math.max(1, matched_line - context_size)
   local end_line = matched_line + context_size
 
   for i = start_line, end_line do
     local line = lines[i]
+
     if line then
-      context_preview[#context_preview + 1] = lines[i]:gsub("%s*$", "")
+      local data = { line_number = i, text = line:gsub("%s*$", "") }
+      context_preview[#context_preview + 1] = data
     end
   end
 

--- a/spec/blink-ripgrep/ripgrep_parser_spec.lua
+++ b/spec/blink-ripgrep/ripgrep_parser_spec.lua
@@ -49,32 +49,40 @@ describe("ripgrep_parser", function()
         ripgrep_parser.get_context_preview(lines, matched_line, context_size)
 
       assert.same(result, {
-        "line 3",
-        "line 4",
-        "line 5",
+        { line_number = 3, text = "line 3" },
+        { line_number = 4, text = "line 4" },
+        { line_number = 5, text = "line 5" },
       })
     end)
 
     it("does not crash if context_size is too large", function()
-      local lines = { "line 1" }
+      local lines = {
+        [1] = "line 1",
+      }
 
       local matched_line = 1
       local context_size = 10
       local result =
         ripgrep_parser.get_context_preview(lines, matched_line, context_size)
 
-      assert.same(result, lines)
+      assert.same(result, {
+        { line_number = 1, text = "line 1" },
+      })
     end)
 
     it("does not crash if context_size is too small", function()
-      local lines = { "line 1" }
+      local lines = {
+        "line 1",
+      }
 
       local matched_line = 1
       local context_size = 0
       local result =
         ripgrep_parser.get_context_preview(lines, matched_line, context_size)
 
-      assert.same(result, lines)
+      assert.same(result, {
+        { line_number = 1, text = "line 1" },
+      })
     end)
 
     it("can display context around the match at the end of the file", function()
@@ -91,9 +99,9 @@ describe("ripgrep_parser", function()
         ripgrep_parser.get_context_preview(lines, matched_line, context_size)
 
       assert.same(result, {
-        "line 8",
-        "line 9",
-        "line 10",
+        { line_number = 8, text = "line 8" },
+        { line_number = 9, text = "line 9" },
+        { line_number = 10, text = "line 10" },
       })
     end)
   end)


### PR DESCRIPTION
When a match has been found in a file in the project, the documentation
window should show a preview of the match context (lines around the
match), and highlight the part where the match was found. This way the
user can quickly get an idea of where the match was found.

By default, the match is highlighted with the `BlinkRipgrepMatch`
highlight group, which is linked to (looks like) the `Search` highlight
group.


https://github.com/user-attachments/assets/0bc7485e-4140-4f85-9fa3-54b0ff88f3d0

