### PR TITLE
feat!: don't show "(rg)" in the label by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ return {
             -- that is bundled in Neovim.
             fallback_to_regex_highlighting = true,
           },
+          -- (optional) customize how the results are displayed. Many options
+          -- are available - make sure your lua LSP is set up so you get
+          -- autocompletion help
+          transform_items = function(_, items)
+            for _, item in ipairs(items) do
+              -- example: append a description to easily distinguish rg results
+              item.labelDetails = {
+                description = "(rg)",
+              }
+            end
+            return items
+          end,
         },
       },
       keymap = {

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -60,6 +60,14 @@ local plugins = {
           ripgrep = {
             module = "blink-ripgrep",
             name = "Ripgrep",
+            transform_items = function(_, items)
+              for _, item in ipairs(items) do
+                item.labelDetails = {
+                  description = "(rg)",
+                }
+              end
+              return items
+            end,
             ---@type blink-ripgrep.Options
             -- opts = {
             --   Keep the default options empty for tests, so that the we can

--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -221,7 +221,7 @@ function RgSource:get_completions(context, resolve)
           -- PERF: only register the match once - right now there is no useful
           -- way to display the same match multiple times
           if not items[matchkey] then
-            local label = match.match.text .. " (rg)"
+            local label = match.match.text
             local docstring = ""
             for _, line in ipairs(match.context_preview) do
               docstring = docstring .. line.text .. "\n"


### PR DESCRIPTION
BREAKING CHANGE: The label will no longer show "(rg)" by default for blink-ripgrep results. If you want to preserve the previous behavior, you can copy the `transform_items` option from the README to your configuration.

It's much better to do it this way because
- not all users like it
- it can also be used to customize other display aspects of the results
- blink uses a different color for the label description, so it's even easier to distinguish the results

Adding a  custom description looks like this
<img width="767" alt="image" src="https://github.com/user-attachments/assets/9971e6f6-ebf6-46cc-8b6a-8a8a7af9dc3e" />


Closes https://github.com/mikavilpas/blink-ripgrep.nvim/issues/64