### PR TITLE
feat: add a debug mode that prints the rg command that was used

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ return {
             -- treesitter parser installed, fall back to regex based highlighting
             -- that is bundled in Neovim.
             fallback_to_regex_highlighting = true,
+
+            -- Show debug information in `:messages` that can help in
+            -- diagnosing issues with the plugin.
+            debug = false,
           },
           -- (optional) customize how the results are displayed. Many options
           -- are available - make sure your lua LSP is set up so you get
@@ -144,6 +148,11 @@ few things you can do to improve performance:
   performance.
 - Use the `max_filesize` option to exclude large files from the search. This can
   prevent performance issues when searching in projects with large files.
+- Disable automatic mode and use the manual mode to start the search only when
+  you need it (see below).
+- Set the `debug = true` option, which will log debug information to your
+  `:messages` in Neovim. You can copy paste these commands to your terminal and
+  try to figure out why the search is slow.
 - If you still experience performance issues, please open an issue for
   discussion.
 

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -36,11 +36,11 @@ export const MyTestDirectorySchema = z.object({
       name: z.literal("config-modifications/"),
       type: z.literal("directory"),
       contents: z.object({
-        ".gitkeep": z.object({
-          name: z.literal(".gitkeep"),
+        "don't_use_debug_mode.lua": z.object({
+          name: z.literal("don't_use_debug_mode.lua"),
           type: z.literal("file"),
-          extension: z.literal(""),
-          stem: z.literal(".gitkeep"),
+          extension: z.literal("lua"),
+          stem: z.literal("don't_use_debug_mode."),
         }),
         "use_case_sensitive_search.lua": z.object({
           name: z.literal("use_case_sensitive_search.lua"),
@@ -131,7 +131,7 @@ export const testDirectoryFiles = z.enum([
   ".config/nvim/init.lua",
   ".config/nvim",
   ".config",
-  "config-modifications/.gitkeep",
+  "config-modifications/don't_use_debug_mode.lua",
   "config-modifications/use_case_sensitive_search.lua",
   "config-modifications/use_manual_mode.lua",
   "config-modifications",

--- a/integration-tests/cypress/e2e/blink-ripgrep/basic_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/basic_spec.cy.ts
@@ -39,7 +39,12 @@ describe("the basics", () => {
   it("allows invoking manually as a blink-cmp keymap", () => {
     cy.visit("/")
     cy.startNeovim({
-      startupScriptModifications: ["use_manual_mode.lua"],
+      startupScriptModifications: [
+        "use_manual_mode.lua",
+        // make sure this is tested somewhere. it doesn't really belong to this
+        // specific test, but it should be tested 🙂
+        "don't_use_debug_mode.lua",
+      ],
     }).then(() => {
       // wait until text on the start screen is visible
       cy.contains("If you see this text, Neovim is ready!")

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -17,7 +17,7 @@
     "zod": "3.24.1"
   },
   "devDependencies": {
-    "@tui-sandbox/library": "7.5.4",
+    "@tui-sandbox/library": "7.5.5",
     "@types/node": "22.10.3",
     "@types/tinycolor2": "1.4.6",
     "@typescript-eslint/eslint-plugin": "8.19.0",

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -69,10 +69,9 @@ local plugins = {
               return items
             end,
             ---@type blink-ripgrep.Options
-            -- opts = {
-            --   Keep the default options empty for tests, so that the we can
-            --   make sure they are supported without specifying them
-            -- },
+            opts = {
+              debug = true,
+            },
           },
         },
       },

--- a/integration-tests/test-environment/config-modifications/don't_use_debug_mode.lua
+++ b/integration-tests/test-environment/config-modifications/don't_use_debug_mode.lua
@@ -1,0 +1,3 @@
+require("blink-ripgrep").setup({
+  debug = false,
+})

--- a/lua/blink-ripgrep/ripgrep_command.lua
+++ b/lua/blink-ripgrep/ripgrep_command.lua
@@ -1,0 +1,38 @@
+local RipgrepCommand = {}
+
+---@param prefix string
+---@param options blink-ripgrep.Options
+function RipgrepCommand.get_command(prefix, options)
+  local cmd = {
+    "rg",
+    "--no-config",
+    "--json",
+    "--context=" .. options.context_size,
+    "--word-regexp",
+    "--max-filesize=" .. options.max_filesize,
+    options.search_casing,
+  }
+
+  for _, option in ipairs(options.additional_rg_options) do
+    table.insert(cmd, option)
+  end
+
+  table.insert(cmd, "--")
+  table.insert(cmd, prefix .. "[\\w_-]+")
+
+  local final = {
+    -- NOTE: 2024-11-28 the logic is documented in the README file, and
+    -- should be kept up to date
+    vim.fn.fnameescape(
+      vim.fs.root(0, options.project_root_marker) or vim.fn.getcwd()
+    ),
+  }
+
+  for _, option in ipairs(final) do
+    table.insert(cmd, option)
+  end
+
+  return cmd
+end
+
+return RipgrepCommand

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         version: 3.24.1
     devDependencies:
       '@tui-sandbox/library':
-        specifier: 7.5.4
-        version: 7.5.4(cypress@13.17.0)(prettier@3.4.2)(type-fest@4.31.0)(typescript@5.7.2)
+        specifier: 7.5.5
+        version: 7.5.5(cypress@13.17.0)(prettier@3.4.2)(type-fest@4.31.0)(typescript@5.7.2)
       '@types/node':
         specifier: 22.10.3
         version: 22.10.3
@@ -359,19 +359,19 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
-  '@trpc/client@11.0.0-rc.666':
-    resolution: {integrity: sha512-BP3H0bktY03m7haVT5QoPR4sn30DNJcvFHsA3Msj3uPRY8JLVE03MR4rVG6T7VbcglORKpyMlRxjpUgdRmJErA==}
+  '@trpc/client@11.0.0-rc.682':
+    resolution: {integrity: sha512-zfM6t4tkbQPm/FHK85jcJjJle7FJTj9U8t/ieDzIe3X6DNo66sg6KqQpjkeTJcaj5u2hga1lmv3rc4uob/7D0g==}
     peerDependencies:
-      '@trpc/server': 11.0.0-rc.666+99556c074
-      typescript: '>=5.6.2'
+      '@trpc/server': 11.0.0-rc.682+8650a22e8
+      typescript: '>=5.7.2'
 
-  '@trpc/server@11.0.0-rc.666':
-    resolution: {integrity: sha512-k+jKrdH/owDRRXPR7oPKCQRTu0dOEnqdGh56863ym95sFY8qXE7BhOR8S4WqyZw1CiPZGjRkdFN0q/GsJhKsIA==}
+  '@trpc/server@11.0.0-rc.682':
+    resolution: {integrity: sha512-y8FhLW/UJ8SOyHByvSQW7WvCnbvYioOYhviWD+sRvqkB9f0O8/sEBPJt1mBadWaO/0tygOghkeNC9o1wAsJ8cg==}
     peerDependencies:
-      typescript: '>=5.6.2'
+      typescript: '>=5.7.2'
 
-  '@tui-sandbox/library@7.5.4':
-    resolution: {integrity: sha512-uGUt5XZ3UHyKOudSXIj7wWzBrNQzJgqbNszb6Z6EULQgiRO96c1PYQ3rKPSM4WOCrdBJQhe2iLz9pDOsP2uaZg==}
+  '@tui-sandbox/library@7.5.5':
+    resolution: {integrity: sha512-9dXFnS7iHpSHMT0thl0XyIVpSlQzVAq7xb2elxnCM2rSsDyGoLnFHHhOFEsqq2r29JcRX7EZz79R4Naqjf2ddg==}
     hasBin: true
     peerDependencies:
       cypress: ^13
@@ -2682,20 +2682,20 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
-  '@trpc/client@11.0.0-rc.666(@trpc/server@11.0.0-rc.666(typescript@5.7.2))(typescript@5.7.2)':
+  '@trpc/client@11.0.0-rc.682(@trpc/server@11.0.0-rc.682(typescript@5.7.2))(typescript@5.7.2)':
     dependencies:
-      '@trpc/server': 11.0.0-rc.666(typescript@5.7.2)
+      '@trpc/server': 11.0.0-rc.682(typescript@5.7.2)
       typescript: 5.7.2
 
-  '@trpc/server@11.0.0-rc.666(typescript@5.7.2)':
+  '@trpc/server@11.0.0-rc.682(typescript@5.7.2)':
     dependencies:
       typescript: 5.7.2
 
-  '@tui-sandbox/library@7.5.4(cypress@13.17.0)(prettier@3.4.2)(type-fest@4.31.0)(typescript@5.7.2)':
+  '@tui-sandbox/library@7.5.5(cypress@13.17.0)(prettier@3.4.2)(type-fest@4.31.0)(typescript@5.7.2)':
     dependencies:
       '@catppuccin/palette': 1.7.1
-      '@trpc/client': 11.0.0-rc.666(@trpc/server@11.0.0-rc.666(typescript@5.7.2))(typescript@5.7.2)
-      '@trpc/server': 11.0.0-rc.666(typescript@5.7.2)
+      '@trpc/client': 11.0.0-rc.682(@trpc/server@11.0.0-rc.682(typescript@5.7.2))(typescript@5.7.2)
+      '@trpc/server': 11.0.0-rc.682(typescript@5.7.2)
       '@xterm/addon-attach': 0.11.0(@xterm/xterm@5.5.0)
       '@xterm/addon-fit': 0.10.0(@xterm/xterm@5.5.0)
       '@xterm/xterm': 5.5.0

--- a/spec/blink-ripgrep/get_command_spec.lua
+++ b/spec/blink-ripgrep/get_command_spec.lua
@@ -1,5 +1,6 @@
 local assert = require("luassert")
 local blink_ripgrep = require("blink-ripgrep")
+local RipgrepCommand = require("blink-ripgrep.ripgrep_command")
 
 describe("get_command", function()
   local default_config = vim.tbl_deep_extend("error", {}, blink_ripgrep.config)
@@ -13,7 +14,7 @@ describe("get_command", function()
       additional_rg_options = { "--foo", "--bar" },
     })
     ---@diagnostic disable-next-line: missing-fields
-    local cmd = plugin.get_command({}, "hello")
+    local cmd = RipgrepCommand.get_command("hello", plugin.config)
 
     -- don't compare the last item (the directory) as that changes depending on
     -- the test environment (such as individual developers' machines or ci)
@@ -36,7 +37,7 @@ describe("get_command", function()
   it("allows configuring the context size", function()
     local plugin = blink_ripgrep.new({ context_size = 9 })
     ---@diagnostic disable-next-line: missing-fields
-    local cmd = plugin.get_command({}, "hello")
+    local cmd = RipgrepCommand.get_command("hello", plugin.config)
 
     table.remove(cmd)
     assert.are_same(cmd, {
@@ -55,7 +56,7 @@ describe("get_command", function()
   it("allows configuring the max_filesize", function()
     local plugin = blink_ripgrep.new({ max_filesize = "2M" })
     ---@diagnostic disable-next-line: missing-fields
-    local cmd = plugin.get_command({}, "hello")
+    local cmd = RipgrepCommand.get_command("hello", plugin.config)
 
     table.remove(cmd)
     assert.are_same(cmd, {
@@ -74,7 +75,7 @@ describe("get_command", function()
   it("allows configuring the casing", function()
     local plugin = blink_ripgrep.new({ search_casing = "--smart-case" })
     ---@diagnostic disable-next-line: missing-fields
-    local cmd = plugin.get_command({}, "hello")
+    local cmd = RipgrepCommand.get_command("hello", plugin.config)
 
     table.remove(cmd)
     assert.are_same(cmd, {


### PR DESCRIPTION
Issue
=====

It's difficult to diagnose performance issues with the plugin. Some
users have unfortunately run into this in
https://github.com/mikavilpas/blink-ripgrep.nvim/issues/82

Solution
========

Add a `debug` option to the plugin configuration that prints the rg
command that was used to get completions. The user can then copy paste
the command into their terminal and play around with it.

By default it's off, but can be enabled by setting `debug = true`.