### PR TITLE
feat(debug,opt-in): temporarily highlight the search prefix

### DIFF
--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -117,6 +117,12 @@ local plugins = {
         "BlinkRipgrepMatch",
         { fg = colors.base, bg = colors.mauve }
       )
+
+      vim.api.nvim_set_hl(
+        0,
+        "BlinkRipgrepSearchPrefix",
+        { fg = colors.base, bg = colors.flamingo }
+      )
     end,
   },
 

--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -176,6 +176,7 @@ function RgSource:get_completions(context, resolve)
 
     if RgSource.config.debug then
       command.debugify_for_shell(cmd)
+      require("blink-ripgrep.visualization").flash_search_prefix(prefix)
     end
   end
 

--- a/lua/blink-ripgrep/visualization.lua
+++ b/lua/blink-ripgrep/visualization.lua
@@ -1,0 +1,32 @@
+local visualization = {}
+
+local ns_id = vim.api.nvim_create_namespace("blink_ripgrep_debug")
+
+vim.api.nvim_set_hl(
+  0,
+  "BlinkRipgrepSearchPrefix",
+  { link = "Search", default = true }
+)
+
+---@param prefix string
+function visualization.flash_search_prefix(prefix)
+  vim.api.nvim_buf_clear_namespace(0, ns_id, 0, -1)
+  local cursor = vim.api.nvim_win_get_cursor(0)
+
+  local hlstart = cursor[2] - #prefix
+  local hlend = cursor[2]
+  vim.api.nvim_buf_add_highlight(
+    0,
+    ns_id,
+    "BlinkRipgrepSearchPrefix",
+    cursor[1] - 1,
+    hlstart,
+    hlend
+  )
+
+  vim.defer_fn(function()
+    vim.api.nvim_buf_clear_namespace(0, ns_id, 0, -1)
+  end, 500)
+end
+
+return visualization


### PR DESCRIPTION
Issue
=====

It's hard to understand when exactly ripgrep is called to find matching words in the project. This is an important concern because of performance - ripgrep can take a long time to search through a large project.

Solution
========

Temporarily highlight the search prefix when a new ripgrep search is started. This will help users and maintainers understand the behavior of the plugin.

To enable this feature, set `debug` to `true` in the configuration. It's recommended to only enable this feature when debugging the plugin.