### PR TITLE
test: make sure that only one ripgrep invocation is started

### DIFF
--- a/integration-tests/cypress/e2e/blink-ripgrep/basic_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/basic_spec.cy.ts
@@ -350,8 +350,13 @@ describe("debug mode", () => {
         rgbify(flavors.macchiato.colors.base.rgb),
       )
 
-      // TODO should programmatically check that only one search was started,
-      // this will not catch all cases
+      cy.runLuaCode({
+        luaCode: `return _G.blink_ripgrep_invocations`,
+      }).should((result) => {
+        // ripgrep should only have been invoked once
+        expect(result.value).to.be.an("array")
+        expect(result.value).to.have.length(1)
+      })
     })
   })
 })

--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -177,6 +177,10 @@ function RgSource:get_completions(context, resolve)
     if RgSource.config.debug then
       command.debugify_for_shell(cmd)
       require("blink-ripgrep.visualization").flash_search_prefix(prefix)
+      -- selene: allow(global_usage)
+      _G.blink_ripgrep_invocations = _G.blink_ripgrep_invocations or {}
+      -- selene: allow(global_usage)
+      table.insert(_G.blink_ripgrep_invocations, cmd)
     end
   end
 


### PR DESCRIPTION
This only currently applies when blink finds some initial results. Otherwise each consecutive keypress will start a new search (this is the behavior before this commit).