### PR TITLE
feat(opt-in): kill previous searches when a new search is started

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ return {
     sources = {
       default = {
         "buffer",
-        "ripgrep",  -- 👈🏻 add "ripgrep" here
+        "ripgrep", -- 👈🏻 add "ripgrep" here
       },
       providers = {
         -- 👇🏻👇🏻 add the ripgrep provider config below
@@ -108,6 +108,14 @@ return {
             -- Show debug information in `:messages` that can help in
             -- diagnosing issues with the plugin.
             debug = false,
+
+            -- Features that are not yet stable and might change in the future.
+            future_features = {
+              -- Kill previous searches when a new search is started. This is
+              -- useful to save resources and might become the default in the
+              -- future.
+              kill_previous_searches = false,
+            },
           },
           -- (optional) customize how the results are displayed. Many options
           -- are available - make sure your lua LSP is set up so you get

--- a/integration-tests/cypress/support/tui-sandbox.ts
+++ b/integration-tests/cypress/support/tui-sandbox.ts
@@ -127,5 +127,19 @@ declare global {
 
 afterEach(async () => {
   if (!testWindow) return
-  await testWindow.runExCommand({ command: "messages", log: true })
+  const timeout = new Promise<void>((resolve, reject) =>
+    setTimeout(() => {
+      Cypress.log({
+        name: "timeout when waiting for :messages to finish. Neovim might be stuck.",
+      })
+      reject(
+        "timeout when waiting for :messages to finish. Neovim might be stuck.",
+      )
+    }, 5_000),
+  )
+
+  await Promise.race([
+    timeout,
+    testWindow.runExCommand({ command: "messages" }),
+  ])
 })

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -17,7 +17,7 @@
     "zod": "3.24.1"
   },
   "devDependencies": {
-    "@tui-sandbox/library": "7.5.5",
+    "@tui-sandbox/library": "7.5.6",
     "@types/node": "22.10.3",
     "@types/tinycolor2": "1.4.6",
     "@typescript-eslint/eslint-plugin": "8.19.0",

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -71,6 +71,9 @@ local plugins = {
             ---@type blink-ripgrep.Options
             opts = {
               debug = true,
+              future_features = {
+                kill_previous_searches = true,
+              },
             },
           },
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         version: 3.24.1
     devDependencies:
       '@tui-sandbox/library':
-        specifier: 7.5.5
-        version: 7.5.5(cypress@13.17.0)(prettier@3.4.2)(type-fest@4.31.0)(typescript@5.7.2)
+        specifier: 7.5.6
+        version: 7.5.6(cypress@13.17.0)(prettier@3.4.2)(type-fest@4.31.0)(typescript@5.7.2)
       '@types/node':
         specifier: 22.10.3
         version: 22.10.3
@@ -370,8 +370,8 @@ packages:
     peerDependencies:
       typescript: '>=5.7.2'
 
-  '@tui-sandbox/library@7.5.5':
-    resolution: {integrity: sha512-9dXFnS7iHpSHMT0thl0XyIVpSlQzVAq7xb2elxnCM2rSsDyGoLnFHHhOFEsqq2r29JcRX7EZz79R4Naqjf2ddg==}
+  '@tui-sandbox/library@7.5.6':
+    resolution: {integrity: sha512-lcqCKbFpdwkHkidUbIst+4KUPCRbxYjreZQ6VqCm6JBQO9+V1ERfoA0wjbfeUOoBwKcWpcbsRVTh8Y1m+7lZ2w==}
     hasBin: true
     peerDependencies:
       cypress: ^13
@@ -2691,7 +2691,7 @@ snapshots:
     dependencies:
       typescript: 5.7.2
 
-  '@tui-sandbox/library@7.5.5(cypress@13.17.0)(prettier@3.4.2)(type-fest@4.31.0)(typescript@5.7.2)':
+  '@tui-sandbox/library@7.5.6(cypress@13.17.0)(prettier@3.4.2)(type-fest@4.31.0)(typescript@5.7.2)':
     dependencies:
       '@catppuccin/palette': 1.7.1
       '@trpc/client': 11.0.0-rc.682(@trpc/server@11.0.0-rc.682(typescript@5.7.2))(typescript@5.7.2)

--- a/vim.toml
+++ b/vim.toml
@@ -20,6 +20,9 @@ type = "function"
 [[after_each.args]]
 type = "function"
 
+[assert]
+any = true
+
 [assert.is_not]
 any = true
 


### PR DESCRIPTION
Issue
=====

When typing text, if there are no matches for a ripgrep search, each
keypresses starts a new ripgrep search. This can lead to many searches
being active at the same time. This takes up resources and is not useful
(if the word did not match previously, it will never match with a longer
search string).

Solution
========

Stop previously running searches when a new search is started. This is
currently disabled by default (soft launch). To opt in, see the README.

If this works well for some time, it might become the default in the
future.