### PR TITLE
perf: kill previous ripgrep searches when a new search is started

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,14 +108,6 @@ return {
             -- Show debug information in `:messages` that can help in
             -- diagnosing issues with the plugin.
             debug = false,
-
-            -- Features that are not yet stable and might change in the future.
-            future_features = {
-              -- Kill previous searches when a new search is started. This is
-              -- useful to save resources and might become the default in the
-              -- future.
-              kill_previous_searches = false,
-            },
           },
           -- (optional) customize how the results are displayed. Many options
           -- are available - make sure your lua LSP is set up so you get

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -71,9 +71,6 @@ local plugins = {
             ---@type blink-ripgrep.Options
             opts = {
               debug = true,
-              future_features = {
-                kill_previous_searches = true,
-              },
             },
           },
         },

--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -11,10 +11,6 @@
 ---@field fallback_to_regex_highlighting? boolean # (default: true) When a result is found for a file whose filetype does not have a treesitter parser installed, fall back to regex based highlighting that is bundled in Neovim.
 ---@field project_root_marker? unknown # Specifies how to find the root of the project where the ripgrep search will start from. Accepts the same options as the marker given to `:h vim.fs.root()` which offers many possibilities for configuration. Defaults to ".git".
 ---@field debug? boolean # Show debug information in `:messages` that can help in diagnosing issues with the plugin.
----@field future_features? blink-ripgrep.FutureFeatures # Features that are not yet stable and might change in the future.
-
----@class blink-ripgrep.FutureFeatures
----@field kill_previous_searches? boolean # Kill previous searches when a new search is started. This is useful to save resources and might become the default in the future.
 
 ---@class blink-ripgrep.RgSource : blink.cmp.Source
 ---@field get_command fun(context: blink.cmp.Context, prefix: string): string[]
@@ -59,9 +55,6 @@ RgSource.config = {
   search_casing = "--ignore-case",
   fallback_to_regex_highlighting = true,
   project_root_marker = ".git",
-  future_features = {
-    kill_previous_searches = false,
-  },
 }
 
 -- set up default options so that they are used by the next search
@@ -164,9 +157,6 @@ local function render_item_documentation(opts, file, match)
   )
 end
 
----@type vim.Ringbuf<vim.SystemObj>
-local ripgrep_invocations = vim.ringbuf(3)
-
 function RgSource:get_completions(context, resolve)
   local prefix = self.get_prefix(context)
 
@@ -192,23 +182,6 @@ function RgSource:get_completions(context, resolve)
       -- selene: allow(global_usage)
       table.insert(_G.blink_ripgrep_invocations, cmd)
     end
-  end
-
-  local kill_previous_searches = (
-    RgSource.config.future_features
-    and RgSource.config.future_features.kill_previous_searches
-  ) or false
-
-  if kill_previous_searches then
-    -- drain all previous invocations and kill them to save resources
-    for val in ripgrep_invocations do
-      ---@cast val vim.SystemObj
-      val:kill(9)
-      if RgSource.config.debug then
-        vim.api.nvim_exec2("echomsg 'killed previous invocation'", {})
-      end
-    end
-    assert(#ripgrep_invocations == 0)
   end
 
   local rg = vim.system(cmd, nil, function(result)
@@ -272,8 +245,11 @@ function RgSource:get_completions(context, resolve)
     end)
   end)
 
-  if kill_previous_searches then
-    ripgrep_invocations:push(rg)
+  return function()
+    rg:kill(9)
+    if RgSource.config.debug then
+      vim.api.nvim_exec2("echomsg 'killed previous invocation'", {})
+    end
   end
 end
 


### PR DESCRIPTION
This supersedes the previous `future_features` version of kill_previous_searches. That should be removed, as this is now the default.

Closes https://github.com/mikavilpas/blink-ripgrep.nvim/issues/102