### PR TITLE
feat: allow canceling the search with `project_root_fallback = false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ return {
             -- - { ".git", "package.json", ".root" }
             project_root_marker = ".git",
 
+            -- Enable fallback to neovim cwd if project_root_marker is not
+            -- found. Default: `true`, which means to use the cwd.
+            project_root_fallback = true,
+
             -- The casing to use for the search in a format that ripgrep
             -- accepts. Defaults to "--ignore-case". See `rg --help` for all the
             -- available options ripgrep supports, but you can try

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -42,6 +42,12 @@ export const MyTestDirectorySchema = z.object({
       name: z.literal("config-modifications/"),
       type: z.literal("directory"),
       contents: z.object({
+        "disable_project_root_fallback.lua": z.object({
+          name: z.literal("disable_project_root_fallback.lua"),
+          type: z.literal("file"),
+          extension: z.literal("lua"),
+          stem: z.literal("disable_project_root_fallback."),
+        }),
         "don't_use_debug_mode.lua": z.object({
           name: z.literal("don't_use_debug_mode.lua"),
           type: z.literal("file"),
@@ -65,6 +71,12 @@ export const MyTestDirectorySchema = z.object({
           type: z.literal("file"),
           extension: z.literal("lua"),
           stem: z.literal("use_manual_mode."),
+        }),
+        "use_not_found_project_root.lua": z.object({
+          name: z.literal("use_not_found_project_root.lua"),
+          type: z.literal("file"),
+          extension: z.literal("lua"),
+          stem: z.literal("use_not_found_project_root."),
         }),
       }),
     }),
@@ -162,10 +174,12 @@ export const testDirectoryFiles = z.enum([
   ".config/nvim/prepare.lua",
   ".config/nvim",
   ".config",
+  "config-modifications/disable_project_root_fallback.lua",
   "config-modifications/don't_use_debug_mode.lua",
   "config-modifications/set_ignore_paths.lua",
   "config-modifications/use_case_sensitive_search.lua",
   "config-modifications/use_manual_mode.lua",
+  "config-modifications/use_not_found_project_root.lua",
   "config-modifications",
   "initial-file.txt",
   "limited/dir with spaces/file with spaces.txt",

--- a/integration-tests/cypress/e2e/blink-ripgrep/basic_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/basic_spec.cy.ts
@@ -199,6 +199,58 @@ describe("searching inside projects", () => {
     })
   })
 
+  it("does not search if the project root is not found", () => {
+    cy.visit("/")
+    cy.startNeovim({
+      filename: "limited/subproject/file1.lua",
+      startupScriptModifications: [
+        "use_not_found_project_root.lua",
+        "disable_project_root_fallback.lua",
+      ],
+    }).then((nvim) => {
+      // when opening a file from a subproject, the search should be limited to
+      // the nearest .git directory (only the files in the same project should
+      // be searched)
+      cy.contains("This is text from file1.lua")
+      createFakeGitDirectoriesToLimitRipgrepScope()
+
+      // make sure the preconditions for this case are met
+      nvim.runLuaCode({
+        luaCode: `assert(require("blink-ripgrep").config.project_root_fallback == false)`,
+      })
+
+      // search for something that was found in the previous test (so we know
+      // it should be found)
+      cy.typeIntoTerminal("cc")
+      cy.typeIntoTerminal("some")
+
+      // because the project root is not found, the search should not have
+      // found anything
+      cy.contains("here").should("not.exist")
+
+      nvim
+        .runLuaCode({
+          luaCode: `return _G.blink_ripgrep_invocations`,
+        })
+        .should((result) => {
+          expect(result.value).to.eql([
+            ["ignored-because-no-command"],
+            ["ignored-because-no-command"],
+          ])
+        })
+
+      nvim.runExCommand({ command: "messages" }).then((result) => {
+        // make sure the search was logged to be skipped due to not finding the
+        // root directory, etc. basically we want to double check it was
+        // skipped for this exact reason and not due to some other possible
+        // bug
+        expect(result.value).to.contain(
+          "no command returned, skipping the search",
+        )
+      })
+    })
+  })
+
   describe("custom ripgrep options", () => {
     it("allows using a custom search_casing when searching", () => {
       cy.visit("/")

--- a/integration-tests/test-environment/config-modifications/disable_project_root_fallback.lua
+++ b/integration-tests/test-environment/config-modifications/disable_project_root_fallback.lua
@@ -1,0 +1,3 @@
+require("blink-ripgrep").setup({
+  project_root_fallback = false,
+})

--- a/integration-tests/test-environment/config-modifications/use_not_found_project_root.lua
+++ b/integration-tests/test-environment/config-modifications/use_not_found_project_root.lua
@@ -1,0 +1,3 @@
+require("blink-ripgrep").setup({
+  project_root_marker = ".this_will_not_be_found",
+})

--- a/lua/blink-ripgrep/ripgrep_command.lua
+++ b/lua/blink-ripgrep/ripgrep_command.lua
@@ -7,7 +7,7 @@ RipgrepCommand.__index = RipgrepCommand
 
 ---@param prefix string
 ---@param options blink-ripgrep.Options
----@return blink-ripgrep.RipgrepCommand
+---@return blink-ripgrep.RipgrepCommand | nil, string? # The command to run, or an error message.
 ---@nodiscard
 function RipgrepCommand.get_command(prefix, options)
   local cmd = {
@@ -27,7 +27,15 @@ function RipgrepCommand.get_command(prefix, options)
   table.insert(cmd, "--")
   table.insert(cmd, prefix .. "[\\w_-]+")
 
-  local root = (vim.fs.root(0, options.project_root_marker) or vim.fn.getcwd())
+  local root = vim.fs.root(0, options.project_root_marker)
+  if options.project_root_fallback then
+    root = root or vim.fn.getcwd()
+  end
+  if root == nil then
+    return nil,
+      "Could not find project root, and project_root_fallback is disabled."
+  end
+
   table.insert(cmd, root)
 
   local command = setmetatable({

--- a/spec/blink-ripgrep/get_command_spec.lua
+++ b/spec/blink-ripgrep/get_command_spec.lua
@@ -15,6 +15,7 @@ describe("get_command", function()
     })
     ---@diagnostic disable-next-line: missing-fields
     local cmd = RipgrepCommand.get_command("hello", plugin.config)
+    assert(cmd)
 
     -- don't compare the last item (the directory) as that changes depending on
     -- the test environment (such as individual developers' machines or ci)
@@ -38,6 +39,7 @@ describe("get_command", function()
     local plugin = blink_ripgrep.new({ context_size = 9 })
     ---@diagnostic disable-next-line: missing-fields
     local cmd = RipgrepCommand.get_command("hello", plugin.config)
+    assert(cmd)
 
     table.remove(cmd.command)
     assert.are_same(cmd.command, {
@@ -57,6 +59,7 @@ describe("get_command", function()
     local plugin = blink_ripgrep.new({ max_filesize = "2M" })
     ---@diagnostic disable-next-line: missing-fields
     local cmd = RipgrepCommand.get_command("hello", plugin.config)
+    assert(cmd)
 
     table.remove(cmd.command)
     assert.are_same(cmd.command, {
@@ -76,6 +79,7 @@ describe("get_command", function()
     local plugin = blink_ripgrep.new({ search_casing = "--smart-case" })
     ---@diagnostic disable-next-line: missing-fields
     local cmd = RipgrepCommand.get_command("hello", plugin.config)
+    assert(cmd)
 
     table.remove(cmd.command)
     assert.are_same(cmd.command, {
@@ -90,4 +94,22 @@ describe("get_command", function()
       "hello[\\w_-]+",
     })
   end)
+
+  it(
+    "allows disabling completion when project_root_fallback is disabled",
+    function()
+      local plugin = blink_ripgrep.new({
+        project_root_fallback = false,
+        project_root_marker = { ".notfound" },
+      })
+      ---@diagnostic disable-next-line: missing-fields
+      local cmd, error_message =
+        RipgrepCommand.get_command("hello", plugin.config)
+      assert.are_same(cmd, nil)
+      assert.are_same(
+        error_message,
+        "Could not find project root, and project_root_fallback is disabled."
+      )
+    end
+  )
 end)


### PR DESCRIPTION
This was originally authored by @joshzcold in https://github.com/mikavilpas/blink-ripgrep.nvim/pull/104

I did a couple of other things in between and decided to start a new branch to simplify porting the changes over to the latest version. The logic should be 100% the same though.