### PR TITLE
feat: enable toggling the plugin on/off with folke/snacks.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ return {
   dependencies = {
     "mikavilpas/blink-ripgrep.nvim",
     -- 👆🏻👆🏻 add the dependency here
+
+    -- optional dependency used for toggling features on/off
+    -- https://github.com/folke/snacks.nvim
+    "folke/snacks.nvim",
   },
   ---@module 'blink.cmp'
   ---@type blink.cmp.Config
@@ -124,6 +128,20 @@ return {
             -- reference material that is not available within the project
             -- root.
             additional_paths = {},
+
+            -- Features that are not yet stable and might change in the future.
+            -- You can enable these to try them out beforehand, but be aware
+            -- that they might change. Nothing is enabled by default.
+            future_features = {
+              -- Keymaps to toggle features on/off. This can be used to alter
+              -- the behavior of the plugin without restarting Neovim. Nothing
+              -- is enabled by default.
+              toggles = {
+                -- The keymap to toggle the plugin on and off from blink
+                -- completion results. Example: "<leader>tg"
+                on_off = "<leader>tg",
+              },
+            },
 
             -- Show debug information in `:messages` that can help in
             -- diagnosing issues with the plugin.

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -56,6 +56,10 @@ export const MyTestDirectorySchema = z.object({
           name: z.literal("don't_use_debug_mode.lua"),
           type: z.literal("file"),
         }),
+        "enable_toggling.lua": z.object({
+          name: z.literal("enable_toggling.lua"),
+          type: z.literal("file"),
+        }),
         "set_ignore_paths.lua": z.object({
           name: z.literal("set_ignore_paths.lua"),
           type: z.literal("file"),
@@ -156,6 +160,7 @@ export const testDirectoryFiles = z.enum([
   "additional-words-dir",
   "config-modifications/disable_project_root_fallback.lua",
   "config-modifications/don't_use_debug_mode.lua",
+  "config-modifications/enable_toggling.lua",
   "config-modifications/set_ignore_paths.lua",
   "config-modifications/use_additional_paths.lua",
   "config-modifications/use_case_sensitive_search.lua",

--- a/integration-tests/cypress/e2e/blink-ripgrep/toggling.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/toggling.cy.ts
@@ -1,0 +1,67 @@
+import { flavors } from "@catppuccin/palette"
+import { rgbify } from "@tui-sandbox/library/dist/src/client/color-utilities"
+import { createFakeGitDirectoriesToLimitRipgrepScope } from "./createFakeGitDirectoriesToLimitRipgrepScope"
+
+describe("toggling features on/off", () => {
+  // Some features can be toggled on/off without restarting Neovim. This can be
+  // useful to combat performance issues, for example.
+  it("can toggle the plugin on/off in blink completions", () => {
+    cy.visit("/")
+    cy.startNeovim({
+      filename: "limited/main-project-file.lua",
+      startupScriptModifications: ["enable_toggling.lua"],
+    }).then((nvim) => {
+      // when completing from a file in a superproject, the search may descend
+      // to subprojects
+      cy.contains("this text is from main-project-file")
+      createFakeGitDirectoriesToLimitRipgrepScope()
+
+      // first verify that the plugin is enabled
+      cy.typeIntoTerminal("o")
+      cy.typeIntoTerminal("some")
+
+      cy.contains("here").should(
+        "have.css",
+        "color",
+        rgbify(flavors.macchiato.colors.green.rgb),
+      )
+
+      cy.typeIntoTerminal("{esc}")
+
+      // toggle the plugin off and wait for confirmation
+      cy.typeIntoTerminal("{esc}")
+      cy.typeIntoTerminal(" tg")
+      cy.contains("Disabled **blink-ripgrep**")
+
+      // try to complete again
+      cy.typeIntoTerminal("ciw")
+      cy.typeIntoTerminal("some")
+
+      nvim
+        .runLuaCode({
+          luaCode: `return _G.blink_ripgrep_invocations`,
+        })
+        .should((result) => {
+          // ripgrep should only have been invoked once
+          expect(result.value).to.be.an("array")
+          const invocations = JSON.stringify(result.value)
+          expect(invocations).to.contain("ignored-because-mode-is-off")
+        })
+
+      // toggle it back on
+      cy.typeIntoTerminal("{esc}")
+      cy.typeIntoTerminal(" tg")
+      cy.contains("Enabled **blink-ripgrep**")
+
+      // try to complete again and verify that the completion is there
+      cy.typeIntoTerminal("ciw")
+      cy.typeIntoTerminal("some")
+
+      cy.contains("here").should(
+        "have.css",
+        "color",
+        rgbify(flavors.macchiato.colors.green.rgb),
+      )
+    })
+  })
+})

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -126,6 +126,7 @@ local plugins = {
     end,
   },
 
+  { "folke/snacks.nvim" },
   { "catppuccin/nvim", name = "catppuccin", priority = 1000 },
 }
 require("lazy").setup({ spec = plugins })

--- a/integration-tests/test-environment/config-modifications/enable_toggling.lua
+++ b/integration-tests/test-environment/config-modifications/enable_toggling.lua
@@ -1,0 +1,8 @@
+require("blink-ripgrep").setup({
+  future_features = {
+    toggles = {
+      -- mnemonic: toggle grep
+      on_off = "<leader>tg",
+    },
+  },
+})


### PR DESCRIPTION
Issue
=====

In some scenarios it's not nice to have blink-ripgrep pop up:
- if there are performance issues
- when giving a presentation
- when recording a video demo

Solution
========

Provide a way to toggle the plugin on/off with a keymap. Right now this is off by default and depends on
https://github.com/folke/snacks.nvim/blob/main/docs/toggle.md

Users that don't want to use this feature or add snacks.nvim can simply ignore it.