### PR TITLE
fix: complicated initialization of the toggling feature

### DIFF
--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -56,10 +56,6 @@ export const MyTestDirectorySchema = z.object({
           name: z.literal("don't_use_debug_mode.lua"),
           type: z.literal("file"),
         }),
-        "enable_toggling.lua": z.object({
-          name: z.literal("enable_toggling.lua"),
-          type: z.literal("file"),
-        }),
         "set_ignore_paths.lua": z.object({
           name: z.literal("set_ignore_paths.lua"),
           type: z.literal("file"),
@@ -160,7 +156,6 @@ export const testDirectoryFiles = z.enum([
   "additional-words-dir",
   "config-modifications/disable_project_root_fallback.lua",
   "config-modifications/don't_use_debug_mode.lua",
-  "config-modifications/enable_toggling.lua",
   "config-modifications/set_ignore_paths.lua",
   "config-modifications/use_additional_paths.lua",
   "config-modifications/use_case_sensitive_search.lua",

--- a/integration-tests/cypress/e2e/blink-ripgrep/toggling.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/toggling.cy.ts
@@ -9,7 +9,6 @@ describe("toggling features on/off", () => {
     cy.visit("/")
     cy.startNeovim({
       filename: "limited/main-project-file.lua",
-      startupScriptModifications: ["enable_toggling.lua"],
     }).then((nvim) => {
       // when completing from a file in a superproject, the search may descend
       // to subprojects

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -71,6 +71,11 @@ local plugins = {
             ---@type blink-ripgrep.Options
             opts = {
               debug = true,
+              future_features = {
+                toggles = {
+                  on_off = "<leader>tg",
+                },
+              },
             },
           },
         },

--- a/integration-tests/test-environment/config-modifications/enable_toggling.lua
+++ b/integration-tests/test-environment/config-modifications/enable_toggling.lua
@@ -1,8 +1,0 @@
-require("blink-ripgrep").setup({
-  future_features = {
-    toggles = {
-      -- mnemonic: toggle grep
-      on_off = "<leader>tg",
-    },
-  },
-})

--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -69,26 +69,8 @@ function RgSource.setup(options)
     end
 
     return
-  end
-
-  local on_off = RgSource.config.future_features.toggles.on_off
-  if on_off then
-    require("snacks.toggle")
-      .new({
-        id = "blink-ripgrep-manual-mode",
-        name = "blink-ripgrep",
-        get = function()
-          return RgSource.config.mode == "on"
-        end,
-        set = function(state)
-          if state then
-            RgSource.config.mode = "on"
-          else
-            RgSource.config.mode = "off"
-          end
-        end,
-      })
-      :map(on_off, { mode = { "n" } })
+  else
+    require("blink-ripgrep.toggles").init_once(RgSource.config)
   end
 end
 
@@ -96,8 +78,7 @@ end
 function RgSource.new(input_opts)
   local self = setmetatable({}, RgSource)
 
-  RgSource.config =
-    vim.tbl_deep_extend("force", RgSource.config, input_opts or {})
+  RgSource.setup(input_opts)
 
   self.get_prefix = RgSource.config.get_prefix
     or require("blink-ripgrep.search_prefix").default_get_prefix

--- a/lua/blink-ripgrep/toggles.lua
+++ b/lua/blink-ripgrep/toggles.lua
@@ -1,0 +1,36 @@
+local toggles = {}
+
+toggles.initialized = false
+
+---@param config blink-ripgrep.Options
+function toggles.init_once(config)
+  if toggles.initialized then
+    return
+  end
+  assert(config.future_features.toggles)
+
+  local on_off = config.future_features.toggles.on_off
+  if not on_off then
+    return
+  end
+
+  require("snacks.toggle")
+    .new({
+      id = "blink-ripgrep-manual-mode",
+      name = "blink-ripgrep",
+      get = function()
+        return config.mode == "on"
+      end,
+      set = function(state)
+        if state then
+          config.mode = "on"
+        else
+          config.mode = "off"
+        end
+      end,
+    })
+    :map(on_off, { mode = { "n" } })
+  toggles.initialized = true
+end
+
+return toggles


### PR DESCRIPTION
Issue
=====

Enabling the toggling feature requires a manual setup call. It's difficult to do in a clean way that avoids duplicating the config.

Solution
========

Simplify the initialization and remove the ability to change the toggling configuration after the initial load. I think that's not a very useful feature anyway.