### PR TITLE
refactor!: render the context preview lazily, not immediately

### DIFF
--- a/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
+++ b/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
@@ -58,8 +58,7 @@ function RipgrepBackend:get_matches(prefix, context, resolve)
       local parsed =
         require("blink-ripgrep.backends.ripgrep.ripgrep_parser").parse(
           lines,
-          cwd,
-          self.config.context_size
+          cwd
         )
       local kinds = require("blink.cmp.types").CompletionItemKind
 
@@ -73,10 +72,6 @@ function RipgrepBackend:get_matches(prefix, context, resolve)
           -- way to display the same match multiple times
           if not items[matchkey] then
             local label = match.match.text
-            local docstring = ""
-            for _, line in ipairs(match.context_preview) do
-              docstring = docstring .. line.text .. "\n"
-            end
 
             local draw_docs = function(draw_opts)
               require("blink-ripgrep.documentation").render_item_documentation(
@@ -91,7 +86,6 @@ function RipgrepBackend:get_matches(prefix, context, resolve)
             items[matchkey] = {
               documentation = {
                 kind = "markdown",
-                value = docstring,
                 draw = draw_docs,
                 -- legacy, will be removed in a future release of blink
                 -- https://github.com/Saghen/blink.cmp/issues/1113

--- a/lua/blink-ripgrep/highlighting.lua
+++ b/lua/blink-ripgrep/highlighting.lua
@@ -6,10 +6,16 @@ local M = {}
 ---@param bufnr number
 ---@param match blink-ripgrep.RipgrepMatch
 ---@param highlight_ns_id number
-function M.highlight_match_in_doc_window(bufnr, match, highlight_ns_id)
+---@param context_preview blink-ripgrep.NumberedLine[]
+function M.highlight_match_in_doc_window(
+  bufnr,
+  match,
+  highlight_ns_id,
+  context_preview
+)
   ---@type number | nil
   local line_in_docs = nil
-  for line, data in ipairs(match.context_preview) do
+  for line, data in ipairs(context_preview) do
     if data.line_number == match.line_number then
       line_in_docs = line
       break
@@ -18,6 +24,7 @@ function M.highlight_match_in_doc_window(bufnr, match, highlight_ns_id)
 
   assert(line_in_docs, "missing line in docs")
 
+  -- highlight the word that matched in this context preview
   vim.api.nvim_buf_set_extmark(
     bufnr,
     highlight_ns_id,

--- a/spec/blink-ripgrep/documentation_spec.lua
+++ b/spec/blink-ripgrep/documentation_spec.lua
@@ -1,0 +1,109 @@
+local documentation = require("blink-ripgrep.documentation")
+local assert = require("luassert")
+
+---@param lines string[]
+local function create_test_file(lines)
+  local target_file_path = vim.fn.tempname()
+  local file = io.open(target_file_path, "w") -- Open or create the file in write mode
+  assert(file, "Failed to create file " .. target_file_path)
+  if file then
+    for _, line in ipairs(lines) do
+      file:write(line .. "\n")
+    end
+    file:close()
+  end
+  local stat = vim.uv.fs_stat(target_file_path)
+  assert(stat)
+  assert(stat.type == "file")
+
+  return target_file_path
+end
+
+describe("get_context_preview", function()
+  it("can display context around the match", function()
+    -- the happy path case
+    local lines = {
+      "line 1",
+      "line 2",
+      "line 3",
+      "line 4",
+      "line 5",
+      "line 6",
+      "line 7",
+      "line 8",
+      "line 9",
+      "line 10",
+    }
+    local file = create_test_file(lines)
+
+    local matched_line = 4
+    local context_size = 1
+    local result =
+      documentation.get_match_context(context_size, matched_line, file)
+
+    assert.same(result, {
+      { line_number = 3, text = "line 3" },
+      { line_number = 4, text = "line 4" },
+      { line_number = 5, text = "line 5" },
+    })
+  end)
+
+  it("does not crash if context_size is too large", function()
+    local lines = {
+      "line 1",
+    }
+    local file = create_test_file(lines)
+
+    local matched_line = 1
+    local context_size = 10
+    local result =
+      documentation.get_match_context(context_size, matched_line, file)
+
+    assert.same(result, {
+      { line_number = 1, text = "line 1" },
+    })
+  end)
+
+  it("does not crash if context_size is too small", function()
+    local lines = {
+      "line 1",
+    }
+    local file = create_test_file(lines)
+
+    local matched_line = 1
+    local context_size = 0
+    local result =
+      documentation.get_match_context(context_size, matched_line, file)
+
+    assert.same(result, {
+      { line_number = 1, text = "line 1" },
+    })
+  end)
+
+  it("can display context around the match at the end of the file", function()
+    local lines = {
+      "line 1",
+      "line 2",
+      "line 3",
+      "line 4",
+      "line 5",
+      "line 6",
+      "line 7",
+      "line 8",
+      "line 9",
+      "line 10",
+    }
+    local file = create_test_file(lines)
+
+    local matched_line = 9
+    local context_size = 1
+    local result =
+      documentation.get_match_context(context_size, matched_line, file)
+
+    assert.same(result, {
+      { line_number = 8, text = "line 8" },
+      { line_number = 9, text = "line 9" },
+      { line_number = 10, text = "line 10" },
+    })
+  end)
+end)

--- a/spec/blink-ripgrep/ripgrep_parser_spec.lua
+++ b/spec/blink-ripgrep/ripgrep_parser_spec.lua
@@ -6,12 +6,11 @@ describe("ripgrep_parser", function()
     vim.fn.readfile("spec/blink-ripgrep/rg-output.jsonl")
 
   it("can parse according to the expected schema", function()
-    local result = ripgrep_parser.parse(ripgrep_output_lines, "/home/user", 1)
+    local result = ripgrep_parser.parse(ripgrep_output_lines, "/home/user")
     local filename = "integration-tests/cypress/e2e/cmp-rg/basic_spec.cy.ts"
 
     assert.is_not_nil(result.files)
     assert.is_not_nil(result.files[filename])
-    assert.is_truthy(#result.files[filename].lines == 0)
     assert.same(result.files[filename].relative_to_cwd, filename)
 
     for _, file in ipairs(result.files) do
@@ -25,84 +24,5 @@ describe("ripgrep_parser", function()
       assert.is_not_nil(submatch.start_col)
       assert.is_not_nil(submatch.end_col)
     end
-  end)
-
-  describe("get_context_preview", function()
-    it("can display context around the match", function()
-      -- the happy path case
-      local lines = {
-        [1] = "line 1",
-        [2] = "line 2",
-        [3] = "line 3",
-        [4] = "line 4",
-        [5] = "line 5",
-        [6] = "line 6",
-        [7] = "line 7",
-        [8] = "line 8",
-        [9] = "line 9",
-        [10] = "line 10",
-      }
-
-      local matched_line = 4
-      local context_size = 1
-      local result =
-        ripgrep_parser.get_context_preview(lines, matched_line, context_size)
-
-      assert.same(result, {
-        { line_number = 3, text = "line 3" },
-        { line_number = 4, text = "line 4" },
-        { line_number = 5, text = "line 5" },
-      })
-    end)
-
-    it("does not crash if context_size is too large", function()
-      local lines = {
-        [1] = "line 1",
-      }
-
-      local matched_line = 1
-      local context_size = 10
-      local result =
-        ripgrep_parser.get_context_preview(lines, matched_line, context_size)
-
-      assert.same(result, {
-        { line_number = 1, text = "line 1" },
-      })
-    end)
-
-    it("does not crash if context_size is too small", function()
-      local lines = {
-        "line 1",
-      }
-
-      local matched_line = 1
-      local context_size = 0
-      local result =
-        ripgrep_parser.get_context_preview(lines, matched_line, context_size)
-
-      assert.same(result, {
-        { line_number = 1, text = "line 1" },
-      })
-    end)
-
-    it("can display context around the match at the end of the file", function()
-      local lines = {
-        [7] = "line 7",
-        [8] = "line 8",
-        [9] = "line 9",
-        [10] = "line 10",
-      }
-
-      local matched_line = 9
-      local context_size = 1
-      local result =
-        ripgrep_parser.get_context_preview(lines, matched_line, context_size)
-
-      assert.same(result, {
-        { line_number = 8, text = "line 8" },
-        { line_number = 9, text = "line 9" },
-        { line_number = 10, text = "line 10" },
-      })
-    end)
   end)
 end)


### PR DESCRIPTION
This should not be a breaking change, but please report any issues.

The motivation for this change is:
- I started to add a backend for git grep, but it does not support getting a context for matches like ripgrep does.
- In many cases, it is wasteful to render the context preview for every match anyway, because there might be 50 matches, and the user might look at only 0-3 of them
- The performance on my machine with this style was good