### PR TITLE
feat(git,opt-in): experimental git grep backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ return {
                 -- completion results. Example: "<leader>tg"
                 on_off = "<leader>tg",
               },
+
+              -- The backend to use for searching. Defaults to "ripgrep".
+              -- "gitgrep" is available as a preview right now.
+              backend = "ripgrep",
             },
 
             -- Show debug information in `:messages` that can help in

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -82,6 +82,10 @@ export const MyTestDirectorySchema = z.object({
           name: z.literal("use_case_sensitive_search.lua"),
           type: z.literal("file"),
         }),
+        "use_gitgrep_backend.lua": z.object({
+          name: z.literal("use_gitgrep_backend.lua"),
+          type: z.literal("file"),
+        }),
         "use_manual_mode.lua": z.object({
           name: z.literal("use_manual_mode.lua"),
           type: z.literal("file"),
@@ -176,6 +180,7 @@ export const testDirectoryFiles = z.enum([
   "config-modifications/set_ignore_paths.lua",
   "config-modifications/use_additional_paths.lua",
   "config-modifications/use_case_sensitive_search.lua",
+  "config-modifications/use_gitgrep_backend.lua",
   "config-modifications/use_manual_mode.lua",
   "config-modifications/use_not_found_project_root.lua",
   "config-modifications",

--- a/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_spec.cy.ts
@@ -1,0 +1,256 @@
+import { flavors } from "@catppuccin/palette"
+import { rgbify } from "@tui-sandbox/library/dist/src/client/color-utilities"
+import type { NeovimContext } from "cypress/support/tui-sandbox"
+import { createGitReposToLimitSearchScope } from "./createGitReposToLimitSearchScope"
+import { verifyGitGrepBackendWasUsedInTest } from "./verifyGitGrepBackendWasUsedInTest"
+
+type NeovimArguments = Parameters<typeof cy.startNeovim>[0]
+
+function startNeovimWithGitBackend(
+  options: Partial<NeovimArguments>,
+): Cypress.Chainable<NeovimContext> {
+  if (!options) options = {}
+  options.startupScriptModifications = options.startupScriptModifications ?? []
+  if (!options.startupScriptModifications.includes("use_gitgrep_backend.lua")) {
+    options.startupScriptModifications.push("use_gitgrep_backend.lua")
+  }
+  assert(options.startupScriptModifications.includes("use_gitgrep_backend.lua"))
+  return cy.startNeovim(options)
+}
+
+describe("the GitGrepBackend", () => {
+  it("shows words in other files as suggestions", () => {
+    cy.visit("/")
+    startNeovimWithGitBackend({}).then((nvim) => {
+      // wait until text on the start screen is visible
+      cy.contains("If you see this text, Neovim is ready!")
+      createGitReposToLimitSearchScope()
+
+      // clear the current line and enter insert mode
+      cy.typeIntoTerminal("cc")
+
+      // this will match text from ../../../test-environment/other-file.lua
+      //
+      // If the plugin works, this text should show up as a suggestion.
+      cy.typeIntoTerminal("hip")
+      cy.contains("Hippopotamus" + "234 (rg)") // wait for blink to show up
+      cy.typeIntoTerminal("234")
+
+      // should show documentation with more details about the match
+      //
+      // should show the text for the matched line
+      //
+      // the text should also be syntax highlighted
+      cy.contains("was my previous password").should(
+        "have.css",
+        "color",
+        rgbify(flavors.macchiato.colors.green.rgb),
+      )
+
+      // should show the file name
+      cy.contains(nvim.dir.contents["other-file.lua"].name)
+    })
+  })
+
+  it("allows invoking manually as a blink-cmp keymap", () => {
+    cy.visit("/")
+    startNeovimWithGitBackend({
+      startupScriptModifications: [
+        "use_manual_mode.lua",
+        // make sure this is tested somewhere. it doesn't really belong to this
+        // specific test, but it should be tested 🙂
+        "don't_use_debug_mode.lua",
+      ],
+    }).then(() => {
+      // wait until text on the start screen is visible
+      cy.contains("If you see this text, Neovim is ready!")
+      createGitReposToLimitSearchScope()
+
+      // clear the current line and enter insert mode
+      cy.typeIntoTerminal("cc")
+
+      // type some text that will match, but add a space so that we can make
+      // sure the completion is not shown automatically (the previous word is
+      // not found after a space)
+      cy.typeIntoTerminal("hip {backspace}")
+
+      // get back into position and invoke the completion manually
+      cy.typeIntoTerminal("{control+g}")
+      cy.contains("Hippopotamus" + "234 (rg)")
+    })
+  })
+
+  it("can use an underscore (_) ca be used to trigger blink completions", () => {
+    cy.visit("/")
+    startNeovimWithGitBackend({}).then(() => {
+      // wait until text on the start screen is visible
+      cy.contains("If you see this text, Neovim is ready!")
+      createGitReposToLimitSearchScope()
+
+      // clear the current line and enter insert mode
+      cy.typeIntoTerminal("cc")
+      cy.typeIntoTerminal("foo")
+      // verify that a suggestion shows up, then cancel it with escape
+      cy.contains("foo_bar")
+      cy.typeIntoTerminal("{esc}")
+      cy.contains("foo_bar").should("not.exist")
+
+      // verify that the suggestion can be shown again by adding an underscore
+      cy.typeIntoTerminal("a_")
+      cy.contains("foo_bar")
+    })
+  })
+
+  it("shows 5 lines around the match by default", () => {
+    // The match context means the lines around the matched line.
+    // We want to show context so that the user can see/remember where the match
+    // was found. Although we don't explicitly show all the matches in the
+    // project, this can still be very useful.
+    cy.visit("/")
+    startNeovimWithGitBackend({}).then(() => {
+      cy.contains("If you see this text, Neovim is ready!")
+      createGitReposToLimitSearchScope()
+
+      cy.typeIntoTerminal("cc")
+
+      // find a match that has more than 5 lines of context
+      cy.typeIntoTerminal("line_7")
+
+      // we should now see lines 2-12 (default 5 lines of context around the match)
+      cy.contains(`"This is line 1"`).should("not.exist")
+      assertMatchVisible(`"This is line 2"`)
+      assertMatchVisible(`"This is line 3"`)
+      assertMatchVisible(`"This is line 4"`)
+      assertMatchVisible(`"This is line 5"`)
+      assertMatchVisible(`"This is line 6"`)
+      assertMatchVisible(`"This is line 7"`) // the match
+      assertMatchVisible(`"This is line 8"`)
+      assertMatchVisible(`"This is line 9"`)
+      assertMatchVisible(`"This is line 10"`)
+      assertMatchVisible(`"This is line 11"`)
+      assertMatchVisible(`"This is line 12"`)
+      cy.contains(`"This is line 13"`).should("not.exist")
+    })
+  })
+
+  function assertMatchVisible(
+    match: string,
+    color?: typeof flavors.macchiato.colors.green.rgb,
+  ) {
+    cy.contains(match).should(
+      "have.css",
+      "color",
+      rgbify(color ?? flavors.macchiato.colors.green.rgb),
+    )
+  }
+
+  afterEach(() => {
+    verifyGitGrepBackendWasUsedInTest()
+  })
+})
+
+describe("in debug mode", () => {
+  it("can execute the debug command in a shell", () => {
+    cy.visit("/")
+    startNeovimWithGitBackend({}).then((nvim) => {
+      // wait until text on the start screen is visible
+      cy.contains("If you see this text, Neovim is ready!")
+      createGitReposToLimitSearchScope()
+
+      // clear the current line and enter insert mode
+      cy.typeIntoTerminal("cc")
+
+      cy.typeIntoTerminal("spa")
+      cy.contains("spaceroni-macaroni")
+
+      nvim.runExCommand({ command: "messages" }).then((result) => {
+        // make sure the logged command can be run in a shell
+        expect(result.value)
+        cy.log(result.value ?? "")
+
+        cy.typeIntoTerminal("{esc}:term{enter}", { delay: 3 })
+
+        // get the current buffer name
+        nvim.runExCommand({ command: "echo expand('%')" }).then((bufname) => {
+          cy.log(bufname.value ?? "")
+          expect(bufname.value).to.contain("term://")
+        })
+
+        // start insert mode
+        cy.typeIntoTerminal("a")
+
+        // Quickly send the text over instead of typing it out. Cypress is a
+        // bit slow when writing a lot of text.
+        nvim.runLuaCode({
+          luaCode: `vim.api.nvim_feedkeys([[${result.value}]], "n", true)`,
+        })
+        cy.typeIntoTerminal("{enter}")
+
+        // The results will be 5-10 lines of jsonl.
+        // Somewhere in the results, we should see the match, if the search was
+        // successful.
+        cy.contains(`spaceroni-macaroni`)
+      })
+    })
+  })
+
+  it("highlights the search word when a new search is started", () => {
+    cy.visit("/")
+    startNeovimWithGitBackend({}).then((nvim) => {
+      // wait until text on the start screen is visible
+      cy.contains("If you see this text, Neovim is ready!")
+      createGitReposToLimitSearchScope()
+
+      // clear the current line and enter insert mode
+      cy.typeIntoTerminal("cc")
+
+      // debug mode should be on by default for all tests. Otherwise it doesn't
+      // make sense to test this, as nothing will be displayed.
+      nvim.runLuaCode({
+        luaCode: `assert(require("blink-ripgrep").config.debug)`,
+      })
+
+      // this will match text from ../../../test-environment/other-file.lua
+      //
+      // If the plugin works, this text should show up as a suggestion.
+      cy.typeIntoTerminal("hip")
+      // the search should have been started for the prefix "hip"
+      cy.contains("hip").should(
+        "have.css",
+        "backgroundColor",
+        rgbify(flavors.macchiato.colors.flamingo.rgb),
+      )
+      //
+      // blink is now in the Fuzzy(3) stage, and additional keypresses must not
+      // start a new ripgrep search. They must be used for filtering the
+      // results instead.
+      // https://cmp.saghen.dev/development/architecture.html#architecture
+      cy.contains("Hippopotamus" + "234 (rg)") // wait for blink to show up
+      cy.typeIntoTerminal("234")
+
+      // wait for the highlight to disappear to test that too
+      cy.contains("hip").should(
+        "have.css",
+        "backgroundColor",
+        rgbify(flavors.macchiato.colors.base.rgb),
+      )
+
+      nvim
+        .runLuaCode({
+          luaCode: `return _G.blink_ripgrep_invocations`,
+        })
+        .should((result) => {
+          // ripgrep should only have been invoked once
+          expect(result.value).to.be.an("array")
+          expect(result.value).to.have.length(1)
+        })
+    })
+  })
+
+  // TODO add a test for "can clean up (kill) a previous search". This is too
+  // fast and currently needs to be timing based (👎🏻).
+
+  afterEach(() => {
+    verifyGitGrepBackendWasUsedInTest()
+  })
+})

--- a/integration-tests/cypress/e2e/blink-ripgrep/backend_ripgrep_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/backend_ripgrep_spec.cy.ts
@@ -2,7 +2,7 @@ import { flavors } from "@catppuccin/palette"
 import { rgbify } from "@tui-sandbox/library/dist/src/client/color-utilities"
 import { createGitReposToLimitSearchScope } from "./createGitReposToLimitSearchScope"
 
-describe("the basics", () => {
+describe("the RipgrepBackend", () => {
   it("shows words in other files as suggestions", () => {
     cy.visit("/")
     cy.startNeovim().then((nvim) => {
@@ -33,55 +33,6 @@ describe("the basics", () => {
 
       // should show the file name
       cy.contains(nvim.dir.contents["other-file.lua"].name)
-    })
-  })
-
-  it("allows invoking manually as a blink-cmp keymap", () => {
-    cy.visit("/")
-    cy.startNeovim({
-      startupScriptModifications: [
-        "use_manual_mode.lua",
-        // make sure this is tested somewhere. it doesn't really belong to this
-        // specific test, but it should be tested 🙂
-        "don't_use_debug_mode.lua",
-      ],
-    }).then(() => {
-      // wait until text on the start screen is visible
-      cy.contains("If you see this text, Neovim is ready!")
-      createGitReposToLimitSearchScope()
-
-      // clear the current line and enter insert mode
-      cy.typeIntoTerminal("cc")
-
-      // type some text that will match, but add a space so that we can make
-      // sure the completion is not shown automatically (the previous word is
-      // not found after a space)
-      cy.typeIntoTerminal("hip {backspace}")
-
-      // get back into position and invoke the completion manually
-      cy.typeIntoTerminal("{control+g}")
-      cy.contains("Hippopotamus" + "234 (rg)")
-    })
-  })
-
-  it("can use an underscore (_) ca be used to trigger blink completions", () => {
-    cy.visit("/")
-    cy.startNeovim({}).then(() => {
-      // wait until text on the start screen is visible
-      cy.contains("If you see this text, Neovim is ready!")
-      createGitReposToLimitSearchScope()
-
-      // clear the current line and enter insert mode
-      cy.typeIntoTerminal("cc")
-      cy.typeIntoTerminal("foo")
-      // verify that a suggestion shows up, then cancel it with escape
-      cy.contains("foo_bar")
-      cy.typeIntoTerminal("{esc}")
-      cy.contains("foo_bar").should("not.exist")
-
-      // verify that the suggestion can be shown again by adding an underscore
-      cy.typeIntoTerminal("a_")
-      cy.contains("foo_bar")
     })
   })
 
@@ -191,4 +142,149 @@ describe("the basics", () => {
       rgbify(color ?? flavors.macchiato.colors.green.rgb),
     )
   }
+})
+
+describe("in debug mode", () => {
+  it("can execute the debug command in a shell", () => {
+    cy.visit("/")
+    cy.startNeovim({
+      // also test that the plugin can handle spaces in the file path
+      filename: "limited/dir with spaces/file with spaces.txt",
+      startupScriptModifications: ["use_additional_paths.lua"],
+    }).then((nvim) => {
+      // wait until text on the start screen is visible
+      cy.contains("this is file with spaces.txt")
+      nvim.runExCommand({ command: `!mkdir "%:h/.git"` })
+
+      // clear the current line and enter insert mode
+      cy.typeIntoTerminal("cc")
+
+      cy.typeIntoTerminal("spa")
+      cy.contains("spaceroni-macaroni")
+
+      nvim.runExCommand({ command: "messages" }).then((result) => {
+        // make sure the logged command can be run in a shell
+        expect(result.value)
+        cy.log(result.value ?? "")
+
+        cy.typeIntoTerminal("{esc}:term{enter}", { delay: 3 })
+
+        // get the current buffer name
+        nvim.runExCommand({ command: "echo expand('%')" }).then((bufname) => {
+          cy.log(bufname.value ?? "")
+          expect(bufname.value).to.contain("term://")
+        })
+
+        // start insert mode
+        cy.typeIntoTerminal("a")
+
+        // Quickly send the text over instead of typing it out. Cypress is a
+        // bit slow when writing a lot of text.
+        nvim.runLuaCode({
+          luaCode: `vim.api.nvim_feedkeys([[${result.value}]], "n", true)`,
+        })
+        cy.typeIntoTerminal("{enter}")
+
+        // The results will be 5-10 lines of jsonl.
+        // Somewhere in the results, we should see the match, if the search was
+        // successful.
+        cy.contains(`spaceroni-macaroni`)
+
+        // additional_paths should be used
+        cy.contains("words.txt")
+      })
+    })
+  })
+
+  it("highlights the search word when a new search is started", () => {
+    cy.visit("/")
+    cy.startNeovim({}).then((nvim) => {
+      // wait until text on the start screen is visible
+      cy.contains("If you see this text, Neovim is ready!")
+      createGitReposToLimitSearchScope()
+
+      // clear the current line and enter insert mode
+      cy.typeIntoTerminal("cc")
+
+      // debug mode should be on by default for all tests. Otherwise it doesn't
+      // make sense to test this, as nothing will be displayed.
+      nvim.runLuaCode({
+        luaCode: `assert(require("blink-ripgrep").config.debug)`,
+      })
+
+      // this will match text from ../../../test-environment/other-file.lua
+      //
+      // If the plugin works, this text should show up as a suggestion.
+      cy.typeIntoTerminal("hip")
+      // the search should have been started for the prefix "hip"
+      cy.contains("hip").should(
+        "have.css",
+        "backgroundColor",
+        rgbify(flavors.macchiato.colors.flamingo.rgb),
+      )
+      //
+      // blink is now in the Fuzzy(3) stage, and additional keypresses must not
+      // start a new ripgrep search. They must be used for filtering the
+      // results instead.
+      // https://cmp.saghen.dev/development/architecture.html#architecture
+      cy.contains("Hippopotamus" + "234 (rg)") // wait for blink to show up
+      cy.typeIntoTerminal("234")
+
+      // wait for the highlight to disappear to test that too
+      cy.contains("hip").should(
+        "have.css",
+        "backgroundColor",
+        rgbify(flavors.macchiato.colors.base.rgb),
+      )
+
+      nvim
+        .runLuaCode({
+          luaCode: `return _G.blink_ripgrep_invocations`,
+        })
+        .should((result) => {
+          // ripgrep should only have been invoked once
+          expect(result.value).to.be.an("array")
+          expect(result.value).to.have.length(1)
+        })
+    })
+  })
+
+  it("can clean up (kill) a previous search", () => {
+    // to save resources, the plugin should clean up a previous search when a
+    // new search is started. Blink should handle this internally, see
+    // https://github.com/mikavilpas/blink-ripgrep.nvim/issues/102
+
+    cy.visit("/")
+    cy.startNeovim({}).then((nvim) => {
+      // wait until text on the start screen is visible
+      cy.contains("If you see this text, Neovim is ready!")
+      createGitReposToLimitSearchScope()
+
+      // clear the current line and enter insert mode
+      cy.typeIntoTerminal("cc")
+
+      // debug mode should be on by default for all tests. Otherwise it doesn't
+      // make sense to test this, as nothing will be displayed.
+      nvim.runLuaCode({
+        luaCode: `assert(require("blink-ripgrep").config.debug)`,
+      })
+
+      // search for something that does not exist. This should start a couple
+      // of searches
+      cy.typeIntoTerminal("yyyyyy", { delay: 80 })
+      nvim.runExCommand({ command: "messages" }).then((result) => {
+        expect(result.value).to.contain(
+          "killed previous RipgrepBackend invocation",
+        )
+      })
+      nvim
+        .runLuaCode({
+          luaCode: `return _G.blink_ripgrep_invocations`,
+        })
+        .should((result) => {
+          expect(result.value).to.be.an("array")
+          expect(result.value).to.have.length.above(3)
+        })
+    })
+  })
 })

--- a/integration-tests/cypress/e2e/blink-ripgrep/createFakeGitDirectoriesToLimitRipgrepScope.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/createFakeGitDirectoriesToLimitRipgrepScope.ts
@@ -1,0 +1,11 @@
+// this works for both GitGrepBackend and RipgrepBackend
+export function createGitReposToLimitSearchScope(): void {
+  cy.nvim_runBlockingShellCommand({
+    command: "git init && git add . && git commit -m 'initial commit'",
+    cwdRelative: ".",
+  })
+  cy.nvim_runBlockingShellCommand({
+    command: "git init && git add . && git commit -m 'initial commit'",
+    cwdRelative: "limited",
+  })
+}

--- a/integration-tests/cypress/e2e/blink-ripgrep/verifyGitGrepBackendWasUsedInTest.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/verifyGitGrepBackendWasUsedInTest.ts
@@ -1,0 +1,15 @@
+import z from "zod"
+
+export function verifyGitGrepBackendWasUsedInTest(): void {
+  cy.nvim_runLuaCode({
+    luaCode: `return require("blink-ripgrep").config`,
+  }).then((result) => {
+    assert(result.value)
+    const config = z
+      .object({ future_features: z.object({ backend: z.string() }) })
+      .safeParse(result.value)
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    expect(config.error).to.be.undefined
+    expect(config.data?.future_features.backend).to.equal("gitgrep")
+  })
+}

--- a/integration-tests/test-environment/config-modifications/use_gitgrep_backend.lua
+++ b/integration-tests/test-environment/config-modifications/use_gitgrep_backend.lua
@@ -1,0 +1,5 @@
+require("blink-ripgrep").setup({
+  future_features = {
+    backend = "gitgrep",
+  },
+})

--- a/lua/blink-ripgrep/backends/git_grep/git_grep.lua
+++ b/lua/blink-ripgrep/backends/git_grep/git_grep.lua
@@ -1,0 +1,104 @@
+---@module "blink.cmp"
+
+---@class blink-ripgrep.GitGrepBackend : blink-ripgrep.Backend
+local GitGrepBackend = {}
+
+---@param config table
+function GitGrepBackend.new(config)
+  local self = setmetatable({}, { __index = GitGrepBackend })
+  self.config = config
+  return self --[[@as blink-ripgrep.GitGrepBackend]]
+end
+
+function GitGrepBackend:get_matches(prefix, context, resolve)
+  local command_module =
+    require("blink-ripgrep.backends.git_grep.gitgrep_command")
+
+  local cwd = assert(vim.uv.cwd())
+  local cmd = command_module.get_command(prefix)
+
+  if cmd == nil then
+    if self.config.debug then
+      local debug = require("blink-ripgrep.debug")
+      debug.add_debug_message("no command returned, skipping the search")
+      debug.add_debug_invocation({ "ignored-because-no-command" })
+    end
+
+    resolve()
+    return
+  end
+
+  if self.config.debug then
+    if cmd.debugify_for_shell then
+      cmd:debugify_for_shell()
+    end
+
+    require("blink-ripgrep.visualization").flash_search_prefix(prefix)
+    require("blink-ripgrep.debug").add_debug_invocation(cmd)
+  end
+
+  local gitgrep = vim.system(cmd.command, nil, function(result)
+    vim.schedule(function()
+      if result.code ~= 0 then
+        resolve()
+        return
+      end
+
+      local lines = vim.split(result.stdout, "\n")
+      local parser = require("blink-ripgrep.backends.git_grep.git_grep_parser")
+      local output = parser.parse_output(lines, cwd)
+
+      ---@type table<string, blink.cmp.CompletionItem>
+      local items = {}
+      for _, file in pairs(output.files) do
+        for _, match in pairs(file.matches) do
+          local draw_docs = function(draw_opts)
+            require("blink-ripgrep.documentation").render_item_documentation(
+              self.config,
+              draw_opts,
+              file,
+              match
+            )
+          end
+
+          ---@diagnostic disable-next-line: missing-fields
+          items[match.match.text] = {
+            documentation = {
+              kind = "markdown",
+              draw = draw_docs,
+              -- legacy, will be removed in a future release of blink
+              -- https://github.com/Saghen/blink.cmp/issues/1113
+              render = draw_docs,
+            },
+            source_id = "blink-ripgrep",
+            kind = 1,
+            label = match.match.text,
+            insertText = match.match.text,
+          }
+        end
+      end
+
+      -- Had some issues with E550, might be fixed upstream nowadays. See
+      -- https://github.com/mikavilpas/blink-ripgrep.nvim/issues/53
+      vim.schedule(function()
+        resolve({
+          is_incomplete_forward = false,
+          is_incomplete_backward = false,
+          items = vim.tbl_values(items),
+          context = context,
+        })
+      end)
+    end)
+  end)
+
+  return function()
+    gitgrep:kill(9)
+    if self.config.debug then
+      require("blink-ripgrep.debug").add_debug_message(
+        "killed previous GitGrepBackend invocation"
+      )
+    end
+  end
+end
+
+return GitGrepBackend

--- a/lua/blink-ripgrep/backends/git_grep/git_grep_parser.lua
+++ b/lua/blink-ripgrep/backends/git_grep/git_grep_parser.lua
@@ -1,0 +1,67 @@
+local GitGrepParser = {}
+
+-- TODO these types are just copies of the Ripgrep types, they should be shared
+
+---@class(exact) blink-ripgrep.GitgrepOutput
+---@field files table<string, blink-ripgrep.GitgrepFile>
+
+---@class(exact) blink-ripgrep.GitgrepFile
+---@field language string the treesitter language of the file, used to determine what grammar to highlight the preview with
+---@field matches table<string,blink-ripgrep.Match>
+---@field relative_to_cwd string the relative path of the file to the current working directory
+
+---@param lines string[]
+---@param cwd string
+function GitGrepParser.parse_output(lines, cwd)
+  ---@type blink-ripgrep.GitgrepOutput
+  local output = { files = {} }
+
+  for _, line in ipairs(lines) do
+    -- selene: allow(empty_if)
+    if line == "" or not line then
+      -- ignore
+    else
+      -- example line:
+      -- other-file.lua\\0003\\00014\\0Hippopotamus234
+      local parts = vim.split(line, "\0")
+      assert(#parts == 4, "Unexpected parts in line: " .. line)
+      local filename = parts[1]
+      local line_number = assert(tonumber(parts[2]))
+      local start_col = assert(tonumber(parts[3])) - 1
+      local text = parts[4]
+
+      local relative_filename = filename
+      if filename:sub(1, #cwd) == cwd then
+        relative_filename = filename:sub(#cwd + 2)
+      end
+
+      local file = output.files[relative_filename]
+      if not file then
+        local ft = vim.filetype.match({ filename = filename })
+        local ext = vim.fn.fnamemodify(filename, ":e")
+        local language = ft
+          or vim.treesitter.language.get_lang(ext or "text")
+          or ext
+
+        file = {
+          language = language,
+          matches = {},
+          relative_to_cwd = relative_filename,
+        }
+        output.files[relative_filename] = file
+      end
+      if not file.matches[text] then
+        file.matches[text] = {
+          match = { text = text },
+          start_col = start_col,
+          end_col = start_col + #text,
+          line_number = line_number,
+        }
+      end
+    end
+  end
+
+  return output
+end
+
+return GitGrepParser

--- a/lua/blink-ripgrep/backends/git_grep/gitgrep_command.lua
+++ b/lua/blink-ripgrep/backends/git_grep/gitgrep_command.lua
@@ -1,0 +1,55 @@
+---@class blink-ripgrep.GitgrepCommand
+---@field command string[]
+local GitgrepCommand = {}
+GitgrepCommand.__index = GitgrepCommand
+
+--- Constructor.
+---@param prefix string
+---@return blink-ripgrep.GitgrepCommand | nil, string? # The command to run, or an error message.
+---@nodiscard
+function GitgrepCommand.get_command(prefix)
+  local cmd = {
+    "git",
+    "grep",
+    "--only-matching",
+    "--ignore-case",
+    "--perl-regexp",
+    "--line-number",
+    "--column",
+    -- ignore binary files
+    "-I",
+    "--word-regexp",
+    -- use a null byte as the separator. This avoids issues with whitespace
+    -- being padded in the line and column number output.
+    "--null",
+    "--",
+    prefix .. "[\\w_-]+",
+  }
+
+  -- TODO support additional options to git grep
+
+  local command = setmetatable({
+    command = cmd,
+  }, GitgrepCommand)
+
+  return command
+end
+
+-- Print the command to :messages for debugging purposes.
+function GitgrepCommand:debugify_for_shell()
+  -- print the command to :messages for hacky debugging, but don't show it
+  -- in the ui so that it doesn't interrupt the user's work
+  local debug_cmd = vim.deepcopy(self.command)
+  assert(#debug_cmd == 12, "unexpected command length")
+
+  -- The pattern is not compatible with shell syntax, so escape it
+  -- separately. The user should be able to copy paste it into their posix
+  -- compatible terminal.
+  local pattern = debug_cmd[12]
+  debug_cmd[12] = "'" .. pattern .. "'"
+
+  local things = table.concat(debug_cmd, " ")
+  vim.api.nvim_exec2("echomsg " .. vim.fn.string(things), {})
+end
+
+return GitgrepCommand

--- a/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
+++ b/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
@@ -1,11 +1,11 @@
----@class blink-ripgrep.Backend
+---@class blink-ripgrep.RipgrepBackend : blink-ripgrep.Backend
 local RipgrepBackend = {}
 
 ---@param config table
 function RipgrepBackend.new(config)
   local self = setmetatable({}, { __index = RipgrepBackend })
   self.config = config
-  return self --[[@as blink-ripgrep.Backend]]
+  return self --[[@as blink-ripgrep.RipgrepBackend]]
 end
 
 function RipgrepBackend:get_matches(prefix, context, resolve)
@@ -66,13 +66,11 @@ function RipgrepBackend:get_matches(prefix, context, resolve)
       local items = {}
       for _, file in pairs(parsed.files) do
         for _, match in pairs(file.matches) do
-          local matchkey = match.match.text
+          local match_text = match.match.text
 
           -- PERF: only register the match once - right now there is no useful
           -- way to display the same match multiple times
-          if not items[matchkey] then
-            local label = match.match.text
-
+          if not items[match_text] then
             local draw_docs = function(draw_opts)
               require("blink-ripgrep.documentation").render_item_documentation(
                 self.config,
@@ -83,7 +81,7 @@ function RipgrepBackend:get_matches(prefix, context, resolve)
             end
 
             ---@diagnostic disable-next-line: missing-fields
-            items[matchkey] = {
+            items[match_text] = {
               documentation = {
                 kind = "markdown",
                 draw = draw_docs,
@@ -93,8 +91,8 @@ function RipgrepBackend:get_matches(prefix, context, resolve)
               },
               source_id = "blink-ripgrep",
               kind = kinds.Text,
-              label = label,
-              insertText = matchkey,
+              label = match_text,
+              insertText = match_text,
             }
           end
         end
@@ -117,7 +115,7 @@ function RipgrepBackend:get_matches(prefix, context, resolve)
     rg:kill(9)
     if self.config.debug then
       require("blink-ripgrep.debug").add_debug_message(
-        "killed previous invocation"
+        "killed previous RipgrepBackend invocation"
       )
     end
   end

--- a/lua/blink-ripgrep/backends/ripgrep/ripgrep_command.lua
+++ b/lua/blink-ripgrep/backends/ripgrep/ripgrep_command.lua
@@ -2,7 +2,6 @@
 ---@field command string[]
 ---@field root string
 ---@field additional_roots string[]
----@field debugify_for_shell? fun(self):nil # Echo the command to the messages buffer for debugging purposes.
 local RipgrepCommand = {}
 RipgrepCommand.__index = RipgrepCommand
 
@@ -55,12 +54,16 @@ function RipgrepCommand:debugify_for_shell()
   -- print the command to :messages for hacky debugging, but don't show it
   -- in the ui so that it doesn't interrupt the user's work
   local debug_cmd = vim.deepcopy(self.command)
+  assert(#debug_cmd >= 10)
 
   -- The pattern is not compatible with shell syntax, so escape it
   -- separately. The user should be able to copy paste it into their posix
   -- compatible terminal.
   local pattern = debug_cmd[9]
+  assert(pattern)
   debug_cmd[9] = "'" .. pattern .. "'"
+
+  assert(debug_cmd[10])
   debug_cmd[10] = vim.fn.fnameescape(debug_cmd[10])
 
   local things = table.concat(debug_cmd, " ")

--- a/lua/blink-ripgrep/backends/ripgrep/ripgrep_parser.lua
+++ b/lua/blink-ripgrep/backends/ripgrep/ripgrep_parser.lua
@@ -5,10 +5,10 @@ local M = {}
 
 ---@class blink-ripgrep.RipgrepFile
 ---@field language string the treesitter language of the file, used to determine what grammar to highlight the preview with
----@field matches table<string,blink-ripgrep.RipgrepMatch>
+---@field matches table<string,blink-ripgrep.Match>
 ---@field relative_to_cwd string the relative path of the file to the current working directory
 
----@class blink-ripgrep.RipgrepMatch
+---@class blink-ripgrep.Match
 ---@field line_number number
 ---@field start_col number
 ---@field end_col number
@@ -49,9 +49,8 @@ function M.parse(ripgrep_output, cwd)
           relative_filename = filename:sub(#cwd + 2)
         end
 
-        local ext = vim.fn.fnamemodify(filename, ":e")
-
         local ft = vim.filetype.match({ filename = filename })
+        local ext = vim.fn.fnamemodify(filename, ":e")
         local language = ft
           or vim.treesitter.language.get_lang(ext or "text")
           or ext

--- a/lua/blink-ripgrep/documentation.lua
+++ b/lua/blink-ripgrep/documentation.lua
@@ -1,3 +1,5 @@
+---@module "blink-ripgrep.backends.git_grep.git_grep_parser"
+
 local documentation = {}
 
 local highlight_ns_id = 0
@@ -10,8 +12,8 @@ vim.api.nvim_set_hl(0, "BlinkRipgrepMatch", { link = "Search", default = true })
 
 ---@param config blink-ripgrep.Options
 ---@param draw_opts blink.cmp.CompletionDocumentationDrawOpts
----@param file blink-ripgrep.RipgrepFile
----@param match blink-ripgrep.RipgrepMatch
+---@param file blink-ripgrep.RipgrepFile | blink-ripgrep.GitgrepFile
+---@param match blink-ripgrep.Match | blink-ripgrep.Match
 function documentation.render_item_documentation(config, draw_opts, file, match)
   local bufnr = draw_opts.window:get_buf()
   ---@type string[]

--- a/lua/blink-ripgrep/highlighting.lua
+++ b/lua/blink-ripgrep/highlighting.lua
@@ -4,7 +4,7 @@ local M = {}
 --- shown, highlight the match so that the user can easily see where the match
 --- is.
 ---@param bufnr number
----@param match blink-ripgrep.RipgrepMatch
+---@param match blink-ripgrep.Match
 ---@param highlight_ns_id number
 ---@param context_preview blink-ripgrep.NumberedLine[]
 function M.highlight_match_in_doc_window(


### PR DESCRIPTION
Issue
=====

The performance in huge repositories like
https://github.com/llvm/llvm-project is extremely slow. It takes ripgrep about a minute to search through the entire codebase before any completion suggestions are shown.

Solution
========

Provide a much faster alternative backend that uses `git grep` to search the codebase. This is still beta quality, but I think it can be improved incrementally to be pretty good.

This backend has the following benefits and drawbacks:

Benefits:
- much faster (5 seconds instead of 1 minute in llvm-project)

Drawbacks:
- does not work in non-git repositories
- not very configurable yet, but can be improved
- no way to ignore files based on their size like with ripgrep

Please provide feedback on this! I would like to add good support and tests for
- git submodules
- git worktrees
- any additional features that are cool

Related to https://github.com/mikavilpas/blink-ripgrep.nvim/issues/110