### PR TITLE
refactor!(future): change backend configuration to use a table

### DIFF
--- a/integration-tests/cypress/e2e/blink-ripgrep/verifyGitGrepBackendWasUsedInTest.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/verifyGitGrepBackendWasUsedInTest.ts
@@ -6,10 +6,12 @@ export function verifyGitGrepBackendWasUsedInTest(): void {
   }).then((result) => {
     assert(result.value)
     const config = z
-      .object({ future_features: z.object({ backend: z.string() }) })
+      .object({
+        future_features: z.object({ backend: z.object({ use: z.string() }) }),
+      })
       .safeParse(result.value)
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     expect(config.error).to.be.undefined
-    expect(config.data?.future_features.backend).to.equal("gitgrep")
+    expect(config.data?.future_features.backend.use).to.equal("gitgrep")
   })
 }

--- a/integration-tests/test-environment/config-modifications/use_gitgrep_backend.lua
+++ b/integration-tests/test-environment/config-modifications/use_gitgrep_backend.lua
@@ -1,5 +1,7 @@
 require("blink-ripgrep").setup({
   future_features = {
-    backend = "gitgrep",
+    backend = {
+      use = "gitgrep",
+    },
   },
 })

--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -19,7 +19,10 @@
 
 ---@class blink-ripgrep.FutureFeatures
 ---@field toggles? blink-ripgrep.ToggleKeymaps # Keymaps to toggle features on/off. This can be used to alter the behavior of the plugin without restarting Neovim. Nothing is enabled by default.
----@field backend? blink-ripgrep.BackendSelection # The backend to use for searching. Defaults to "ripgrep". "gitgrep" is available as a preview right now.
+---@field backend? blink-ripgrep.BackendConfig
+
+---@class blink-ripgrep.BackendConfig
+---@field use? blink-ripgrep.BackendSelection # The backend to use for searching. Defaults to "ripgrep". "gitgrep" is available as a preview right now.
 
 ---@alias blink-ripgrep.BackendSelection
 ---| "ripgrep" # Use ripgrep (rg) for searching. Works in most cases.
@@ -58,7 +61,9 @@ RgSource.config = {
   mode = "on",
   future_features = {
     toggles = nil,
-    backend = "ripgrep",
+    backend = {
+      use = "ripgrep",
+    },
   },
 }
 
@@ -108,7 +113,7 @@ function RgSource:get_completions(context, resolve)
   ---@type blink-ripgrep.Backend | nil
   local backend
   do
-    local be = (self.config.future_features or {}).backend
+    local be = (self.config.future_features or {}).backend.use
 
     if be == "gitgrep" then
       backend =


### PR DESCRIPTION
BREAKING CHANGE: If you were using the git_grep backend, you will need to update your configuration to use the new format.

Issue
=====

It's possible to choose between different backends (ripgrep and gitgrep) for the plugin. However, not all configuration options can be supported for all backends. Right now there are many ripgrep specific options that are confusing.

Solution
========

Change the backend configuration to use a table instead of a string. Later on, we can add more configuration options for each backend.