### PR TITLE
test: bump blink.cmp version from 0.10.0 to 0.13.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ integration-tests/dist
 .luarocks
 lua_modules
 luarocks
+integration-tests/cypress/videos

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -39,7 +39,7 @@ local plugins = {
     event = "VeryLazy",
     -- use a release tag to download pre-built binaries
     -- https://github.com/Saghen/blink.cmp/releases
-    version = "v0.10.0",
+    version = "v0.13.1",
 
     -- to (locally) track nightly builds, use the following:
     -- version = false,


### PR DESCRIPTION
# test: bump blink.cmp version from 0.10.0 to 0.13.1


# chore: ignore cypress videos

