### PR TITLE
feat: allow using gitgrep or ripgrep based on the current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,10 @@ return {
               },
 
               -- The backend to use for searching. Defaults to "ripgrep".
-              -- "gitgrep" is available as a preview right now.
+              -- Available options:
+              -- - "ripgrep", always use ripgrep
+              -- - "gitgrep", always use git grep
+              -- - "gitgrep-or-ripgrep", use git grep if possible, otherwise ripgrep
               backend = "ripgrep",
             },
 

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -86,6 +86,10 @@ export const MyTestDirectorySchema = z.object({
           name: z.literal("use_gitgrep_backend.lua"),
           type: z.literal("file"),
         }),
+        "use_gitgrep_or_ripgrep_backend.lua": z.object({
+          name: z.literal("use_gitgrep_or_ripgrep_backend.lua"),
+          type: z.literal("file"),
+        }),
         "use_manual_mode.lua": z.object({
           name: z.literal("use_manual_mode.lua"),
           type: z.literal("file"),
@@ -181,6 +185,7 @@ export const testDirectoryFiles = z.enum([
   "config-modifications/use_additional_paths.lua",
   "config-modifications/use_case_sensitive_search.lua",
   "config-modifications/use_gitgrep_backend.lua",
+  "config-modifications/use_gitgrep_or_ripgrep_backend.lua",
   "config-modifications/use_manual_mode.lua",
   "config-modifications/use_not_found_project_root.lua",
   "config-modifications",

--- a/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_or_ripgrep_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_or_ripgrep_spec.cy.ts
@@ -1,0 +1,46 @@
+import type { NeovimContext } from "cypress/support/tui-sandbox"
+import { createGitReposToLimitSearchScope } from "./createGitReposToLimitSearchScope"
+import { verifyCorrectBackendWasUsedInTest } from "./verifyGitGrepBackendWasUsedInTest"
+
+type NeovimArguments = Parameters<typeof cy.startNeovim>[0]
+
+function startNeovimWithThisBackend(
+  options: Partial<NeovimArguments>,
+): Cypress.Chainable<NeovimContext> {
+  const backend = "use_gitgrep_or_ripgrep_backend.lua"
+
+  if (!options) options = {}
+  options.startupScriptModifications = options.startupScriptModifications ?? []
+
+  if (!options.startupScriptModifications.includes(backend)) {
+    options.startupScriptModifications.push(backend)
+  }
+
+  assert(options.startupScriptModifications.includes(backend))
+  return cy.startNeovim(options)
+}
+
+describe("the GitGrepOrRipgrepBackend", () => {
+  it("shows words in other files as suggestions", () => {
+    cy.visit("/")
+    startNeovimWithThisBackend({}).then((_) => {
+      // wait until text on the start screen is visible
+      cy.contains("If you see this text, Neovim is ready!")
+      createGitReposToLimitSearchScope()
+
+      // clear the current line and enter insert mode
+      cy.typeIntoTerminal("cc")
+
+      // this will match text from ../../../test-environment/other-file.lua
+      //
+      // If the plugin works, this text should show up as a suggestion.
+      cy.typeIntoTerminal("hip")
+      cy.contains("Hippopotamus" + "234 (rg)") // wait for blink to show up
+      cy.typeIntoTerminal("234")
+    })
+  })
+
+  afterEach(() => {
+    verifyCorrectBackendWasUsedInTest("gitgrep-or-ripgrep")
+  })
+})

--- a/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_spec.cy.ts
@@ -2,7 +2,7 @@ import { flavors } from "@catppuccin/palette"
 import { rgbify } from "@tui-sandbox/library/dist/src/client/color-utilities"
 import type { NeovimContext } from "cypress/support/tui-sandbox"
 import { createGitReposToLimitSearchScope } from "./createGitReposToLimitSearchScope"
-import { verifyGitGrepBackendWasUsedInTest } from "./verifyGitGrepBackendWasUsedInTest"
+import { verifyCorrectBackendWasUsedInTest } from "./verifyGitGrepBackendWasUsedInTest"
 
 type NeovimArguments = Parameters<typeof cy.startNeovim>[0]
 
@@ -11,10 +11,13 @@ function startNeovimWithGitBackend(
 ): Cypress.Chainable<NeovimContext> {
   if (!options) options = {}
   options.startupScriptModifications = options.startupScriptModifications ?? []
-  if (!options.startupScriptModifications.includes("use_gitgrep_backend.lua")) {
-    options.startupScriptModifications.push("use_gitgrep_backend.lua")
+
+  const backend = "use_gitgrep_backend.lua"
+  if (!options.startupScriptModifications.includes(backend)) {
+    options.startupScriptModifications.push(backend)
   }
-  assert(options.startupScriptModifications.includes("use_gitgrep_backend.lua"))
+
+  assert(options.startupScriptModifications.includes(backend))
   return cy.startNeovim(options)
 }
 
@@ -145,7 +148,7 @@ describe("the GitGrepBackend", () => {
   }
 
   afterEach(() => {
-    verifyGitGrepBackendWasUsedInTest()
+    verifyCorrectBackendWasUsedInTest("gitgrep")
   })
 })
 
@@ -248,6 +251,6 @@ describe("in debug mode", () => {
   })
 
   afterEach(() => {
-    verifyGitGrepBackendWasUsedInTest()
+    verifyCorrectBackendWasUsedInTest("gitgrep")
   })
 })

--- a/integration-tests/cypress/e2e/blink-ripgrep/debug-mode.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/debug-mode.cy.ts
@@ -1,7 +1,7 @@
 import { flavors } from "@catppuccin/palette"
 import { rgbify } from "@tui-sandbox/library/dist/src/client/color-utilities"
 import { createGitReposToLimitSearchScope } from "./createGitReposToLimitSearchScope"
-import { verifyGitGrepBackendWasUsedInTest } from "./verifyGitGrepBackendWasUsedInTest"
+import { verifyCorrectBackendWasUsedInTest } from "./verifyGitGrepBackendWasUsedInTest"
 
 describe("debug mode", () => {
   it("can execute the debug command in a shell", () => {
@@ -168,7 +168,7 @@ describe("debug mode", () => {
           expect(result.value).to.have.length.above(2)
         })
 
-      verifyGitGrepBackendWasUsedInTest()
+      verifyCorrectBackendWasUsedInTest("gitgrep")
     })
   })
 })

--- a/integration-tests/cypress/e2e/blink-ripgrep/verifyGitGrepBackendWasUsedInTest.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/verifyGitGrepBackendWasUsedInTest.ts
@@ -1,6 +1,8 @@
 import z from "zod"
 
-export function verifyGitGrepBackendWasUsedInTest(): void {
+export function verifyCorrectBackendWasUsedInTest(
+  backend: "gitgrep" | "ripgrep" | "gitgrep-or-ripgrep",
+): void {
   cy.nvim_runLuaCode({
     luaCode: `return require("blink-ripgrep").config`,
   }).then((result) => {
@@ -12,6 +14,6 @@ export function verifyGitGrepBackendWasUsedInTest(): void {
       .safeParse(result.value)
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     expect(config.error).to.be.undefined
-    expect(config.data?.future_features.backend.use).to.equal("gitgrep")
+    expect(config.data?.future_features.backend.use).to.equal(backend)
   })
 }

--- a/integration-tests/test-environment/config-modifications/use_gitgrep_or_ripgrep_backend.lua
+++ b/integration-tests/test-environment/config-modifications/use_gitgrep_or_ripgrep_backend.lua
@@ -1,0 +1,7 @@
+require("blink-ripgrep").setup({
+  future_features = {
+    backend = {
+      use = "gitgrep-or-ripgrep",
+    },
+  },
+})

--- a/lua/blink-ripgrep/backends/git_grep_or_ripgrep/git_grep_or_ripgrep.lua
+++ b/lua/blink-ripgrep/backends/git_grep_or_ripgrep/git_grep_or_ripgrep.lua
@@ -1,0 +1,75 @@
+---@module "blink.cmp"
+
+---@class blink-ripgrep.GitGrepOrRipgrepBackend : blink-ripgrep.Backend
+local GitGrepOrRipgrepBackend = {}
+
+function GitGrepOrRipgrepBackend.new(config)
+  local self = setmetatable({}, { __index = GitGrepOrRipgrepBackend })
+  self.config = config
+  return self --[[@as blink-ripgrep.GitGrepOrRipgrepBackend]]
+end
+
+function GitGrepOrRipgrepBackend:get_matches(prefix, context, resolve)
+  local cwd = assert(vim.uv.cwd())
+
+  if self.config.debug then
+    require("blink-ripgrep.debug").add_debug_message(
+      string.format(
+        "GitGrepOrRipgrepBackend: Finding the backend in %s",
+        vim.inspect(cwd)
+      )
+    )
+  end
+
+  -- use git to check if the current directory is a git repository
+  local backend
+  local job = vim.system({
+    -- git allows checking if the current directory is a git repository this way
+    "git",
+    "rev-parse",
+    "--is-inside-work-tree",
+  }, {
+    cwd = cwd,
+  }, function(result)
+    if result.code == 0 then
+      backend =
+        require("blink-ripgrep.backends.git_grep.git_grep").new(self.config)
+
+      if self.config.debug then
+        vim.schedule(function()
+          require("blink-ripgrep.debug").add_debug_message(
+            string.format(
+              "GitGrepOrRipgrepBackend: Detected a git repository in '%s'. Using the git-grep backend",
+              vim.inspect(cwd)
+            )
+          )
+        end)
+      end
+    else
+      backend =
+        require("blink-ripgrep.backends.ripgrep.ripgrep").new(self.config)
+
+      if self.config.debug then
+        vim.schedule(function()
+          require("blink-ripgrep.debug").add_debug_message(
+            string.format(
+              "GitGrepOrRipgrepBackend: No git repository in '%s'. Using the ripgrep backend",
+              vim.inspect(cwd)
+            )
+          )
+        end)
+      end
+    end
+  end)
+  job:wait(1000)
+
+  assert(
+    backend,
+    "GitGrepOrRipgrepBackend: Was unable to find the backend in " .. cwd
+  )
+
+  local cancellation_function = backend:get_matches(prefix, context, resolve)
+  return cancellation_function
+end
+
+return GitGrepOrRipgrepBackend

--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -25,6 +25,7 @@
 ---@field use? blink-ripgrep.BackendSelection # The backend to use for searching. Defaults to "ripgrep". "gitgrep" is available as a preview right now.
 
 ---@alias blink-ripgrep.BackendSelection
+---| "gitgrep-or-ripgrep" # Use git grep for searching if in a git repository, otherwise use ripgrep.
 ---| "ripgrep" # Use ripgrep (rg) for searching. Works in most cases.
 ---| "gitgrep" # Use git grep for searching. This is faster but only works in git repositories.
 
@@ -121,6 +122,10 @@ function RgSource:get_completions(context, resolve)
     elseif be == "ripgrep" then
       backend =
         require("blink-ripgrep.backends.ripgrep.ripgrep").new(RgSource.config)
+    elseif be == "gitgrep-or-ripgrep" then
+      backend = require(
+        "blink-ripgrep.backends.git_grep_or_ripgrep.git_grep_or_ripgrep"
+      ).new(RgSource.config)
     end
 
     assert(backend, "Invalid backend " .. vim.inspect(be))
@@ -134,7 +139,6 @@ function RgSource:get_completions(context, resolve)
   end
 
   local cancellation_function = backend:get_matches(prefix, context, resolve)
-
   return cancellation_function
 end
 


### PR DESCRIPTION
Issue
=====

Currently, the plugin supports using ripgrep or gitgrep. It allows opting into more performance (gitgrep), or a solution that also works outside of git repositories.

This has to be configured before starting Neovim. However, sometimes users need to edit files in both types of projects. This requires manual work to keep the plugin working.

Solution
========

Add a new `gitgrep-or-ripgrep` backend. It uses gitgrep if the current directory is a git repository, otherwise it uses ripgrep.

Right now the backend is selected based on Neovim's current working directory (cwd). Feedback on this is welcome.