### PR TITLE
Async improvements

### DIFF
--- a/lua/blink-ripgrep/backends/git_grep/git_grep.lua
+++ b/lua/blink-ripgrep/backends/git_grep/git_grep.lua
@@ -40,6 +40,15 @@ function GitGrepBackend:get_matches(prefix, context, resolve)
   local gitgrep = vim.system(cmd.command, nil, function(result)
     vim.schedule(function()
       if result.code ~= 0 then
+        if self.config.debug then
+          require("blink-ripgrep.debug").add_debug_message(
+            string.format(
+              "GitGrepBackend: Failed to execute the command in %s, error code %d",
+              vim.inspect(cwd),
+              result.code
+            )
+          )
+        end
         resolve()
         return
       end
@@ -47,6 +56,12 @@ function GitGrepBackend:get_matches(prefix, context, resolve)
       local lines = vim.split(result.stdout, "\n")
       local parser = require("blink-ripgrep.backends.git_grep.git_grep_parser")
       local output = parser.parse_output(lines, cwd)
+
+      if self.config.debug then
+        require("blink-ripgrep.debug").add_debug_message(
+          string.format("GitGrepBackend: Parsed %d lines of output", #lines)
+        )
+      end
 
       ---@type table<string, blink.cmp.CompletionItem>
       local items = {}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prettier-plugin-organize-imports": "4.1.0",
     "prettier-plugin-packagejson": "2.5.10"
   },
-  "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b",
+  "packageManager": "pnpm@10.6.5+sha512.cdf928fca20832cd59ec53826492b7dc25dc524d4370b6b4adbf65803d32efaa6c1c88147c0ae4e8d579a6c9eec715757b50d4fa35eea179d868eada4ed043af",
   "pnpm": {
     "onlyBuiltDependencies": [
       "core-js",


### PR DESCRIPTION
# perf: avoid blocking the main thread in GitGrepOrRipgrepBackend

Issue
=====

GitGrepOrRipgrepBackend checks if the current directory is a git
repository with a shell command. If this shell command takes a long time
to execute, it will block the main thread, making the UI unresponsive.

Solution
========

Use blink.cmp.lib.async.task and avoid waiting for the shell command to
finish in a blocking manner. This allows the user to keep making edits
in neovim while the shell command is running.

It might be possible to also cancel the task cleanly, but I did not
really test this extensively.

# refactor: add more debug log messages to GitGrepBackend


