### PR TITLE
feat: move toggle keymaps to stable features

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ return {
             -- root.
             additional_paths = {},
 
+            -- Keymaps to toggle features on/off. This can be used to alter
+            -- the behavior of the plugin without restarting Neovim. Nothing
+            -- is enabled by default. Requires folke/snacks.nvim.
+            toggles = {
+              -- The keymap to toggle the plugin on and off from blink
+              -- completion results. Example: "<leader>tg"
+              on_off = nil,
+            },
+
             -- Features that are not yet stable and might change in the future.
             -- You can enable these to try them out beforehand, but be aware
             -- that they might change. Nothing is enabled by default.
@@ -137,15 +146,6 @@ return {
               -- https://github.com/mikavilpas/blink-ripgrep.nvim/issues/185. This
               -- is a temporary fix and will be removed in the future.
               issue185_workaround = false,
-
-              -- Keymaps to toggle features on/off. This can be used to alter
-              -- the behavior of the plugin without restarting Neovim. Nothing
-              -- is enabled by default.
-              toggles = {
-                -- The keymap to toggle the plugin on and off from blink
-                -- completion results. Example: "<leader>tg"
-                on_off = "<leader>tg",
-              },
 
               backend = {
                 -- The backend to use for searching. Defaults to "ripgrep".

--- a/integration-tests/cypress.config.ts
+++ b/integration-tests/cypress.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "cypress"
 export default defineConfig({
   e2e: {
     baseUrl: "http://localhost:3000",
-    video: true,
+    // video: true,
     experimentalRunAllSpecs: true,
     retries: {
       runMode: 5,

--- a/integration-tests/cypress.config.ts
+++ b/integration-tests/cypress.config.ts
@@ -5,6 +5,11 @@ export default defineConfig({
     baseUrl: "http://localhost:3000",
     // video: true,
     experimentalRunAllSpecs: true,
+    env: {
+      // make the CI environment variable available to cypress
+      // https://docs.cypress.io/app/references/environment-variables#Option-1-configuration-file
+      CI: process.env.CI,
+    },
     retries: {
       runMode: 5,
       openMode: 0,

--- a/integration-tests/cypress/e2e/blink-ripgrep/debug-mode.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/debug-mode.cy.ts
@@ -1,5 +1,3 @@
-import { flavors } from "@catppuccin/palette"
-import { rgbify } from "@tui-sandbox/library/dist/src/client/color-utilities"
 import { createGitReposToLimitSearchScope } from "./createGitReposToLimitSearchScope"
 import { verifyCorrectBackendWasUsedInTest } from "./verifyGitGrepBackendWasUsedInTest"
 
@@ -52,53 +50,6 @@ describe("debug mode", () => {
         // additional_paths should be used
         cy.contains("words.txt")
       })
-    })
-  })
-
-  it("highlights the search word when a new ripgrep search is started", () => {
-    cy.visit("/")
-    cy.startNeovim({}).then((nvim) => {
-      // wait until text on the start screen is visible
-      cy.contains("If you see this text, Neovim is ready!")
-      createGitReposToLimitSearchScope()
-
-      // clear the current line and enter insert mode
-      cy.typeIntoTerminal("cc")
-
-      // this will match text from ../../../test-environment/other-file.lua
-      //
-      // If the plugin works, this text should show up as a suggestion.
-      cy.typeIntoTerminal("hip")
-      // the search should have been started for the prefix "hip"
-      cy.contains("hip").should(
-        "have.css",
-        "backgroundColor",
-        rgbify(flavors.macchiato.colors.flamingo.rgb),
-      )
-      //
-      // blink is now in the Fuzzy(3) stage, and additional keypresses must not
-      // start a new ripgrep search. They must be used for filtering the
-      // results instead.
-      // https://cmp.saghen.dev/development/architecture.html#architecture
-      cy.contains("Hippopotamus" + "234 (rg)") // wait for blink to show up
-      cy.typeIntoTerminal("234")
-
-      // wait for the highlight to disappear to test that too
-      cy.contains("hip").should(
-        "have.css",
-        "backgroundColor",
-        rgbify(flavors.macchiato.colors.base.rgb),
-      )
-
-      nvim
-        .runLuaCode({
-          luaCode: `return _G.blink_ripgrep_invocations`,
-        })
-        .should((result) => {
-          // ripgrep should only have been invoked once
-          expect(result.value).to.be.an("array")
-          expect(result.value).to.have.length(1)
-        })
     })
   })
 

--- a/integration-tests/cypress/support/tui-sandbox.ts
+++ b/integration-tests/cypress/support/tui-sandbox.ts
@@ -135,6 +135,12 @@ Cypress.Commands.add(
   },
 )
 
+Cypress.Commands.add("nvim_isRunning", () => {
+  return cy.window().then(async (_) => {
+    return !!testNeovim
+  })
+})
+
 Cypress.Commands.add(
   "startTerminalApplication",
   (args: StartTerminalGenericArguments) => {
@@ -216,6 +222,10 @@ declare global {
       nvim_runExCommand(
         input: ExCommandClientInput,
       ): Chainable<RunExCommandOutput>
+
+      /** Returns true if neovim is running. Useful to conditionally run
+       * afterEach actions based on whether it's running. */
+      nvim_isRunning(): Chainable<boolean>
 
       terminal_runBlockingShellCommand(
         input: MyBlockingCommandClientInput,

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@eslint/js": "9.23.0",
-    "@tui-sandbox/library": "10.0.0",
+    "@tui-sandbox/library": "10.1.0",
     "@types/node": "22.13.14",
     "@types/tinycolor2": "1.4.6",
     "concurrently": "9.1.2",

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -71,10 +71,8 @@ local plugins = {
             ---@type blink-ripgrep.Options
             opts = {
               debug = true,
-              future_features = {
-                toggles = {
-                  on_off = "<leader>tg",
-                },
+              toggles = {
+                on_off = "<leader>tg",
               },
             },
           },

--- a/lua/blink-ripgrep/backends/git_grep/git_grep.lua
+++ b/lua/blink-ripgrep/backends/git_grep/git_grep.lua
@@ -57,12 +57,6 @@ function GitGrepBackend:get_matches(prefix, context, resolve)
       local parser = require("blink-ripgrep.backends.git_grep.git_grep_parser")
       local output = parser.parse_output(lines, cwd)
 
-      if self.config.debug then
-        require("blink-ripgrep.debug").add_debug_message(
-          string.format("GitGrepBackend: Parsed %d lines of output", #lines)
-        )
-      end
-
       ---@type table<string, blink.cmp.CompletionItem>
       local items = {}
       for _, file in pairs(output.files) do

--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -16,9 +16,9 @@
 ---@field additional_paths? string[] # Any additional paths to search in, in addition to the project root. This can be useful if you want to include dictionary files (/usr/share/dict/words), framework documentation, or any other reference material that is not available within the project root.
 ---@field mode? blink-ripgrep.Mode # The mode to use for showing completions. Defaults to automatically showing suggestions.
 ---@field future_features? blink-ripgrep.FutureFeatures # Features that are not yet stable and might change in the future. You can enable these to try them out beforehand, but be aware that they might change. Nothing is enabled by default.
+---@field toggles? blink-ripgrep.ToggleKeymaps # Keymaps to toggle features on/off. This can be used to alter the behavior of the plugin without restarting Neovim. Nothing is enabled by default.
 
 ---@class blink-ripgrep.FutureFeatures
----@field toggles? blink-ripgrep.ToggleKeymaps # Keymaps to toggle features on/off. This can be used to alter the behavior of the plugin without restarting Neovim. Nothing is enabled by default.
 ---@field backend? blink-ripgrep.BackendConfig
 ---@field issue185_workaround? boolean # Workaround for https://github.com/mikavilpas/blink-ripgrep.nvim/issues/185. This is a temporary fix and will be removed in the future.
 
@@ -60,9 +60,11 @@ RgSource.config = {
   ignore_paths = {},
   project_root_fallback = true,
   additional_paths = {},
+  toggles = {
+    on_off = nil,
+  },
   mode = "on",
   future_features = {
-    toggles = nil,
     backend = {
       use = "ripgrep",
     },
@@ -75,7 +77,7 @@ RgSource.config = {
 function RgSource.setup(options)
   RgSource.config = vim.tbl_deep_extend("force", RgSource.config, options or {})
 
-  if not RgSource.config.future_features.toggles then
+  if not RgSource.config.toggles then
     if RgSource.config.debug then
       require("blink-ripgrep.debug").add_debug_message(
         "not enabling toggles because the feature is not enabled"

--- a/lua/blink-ripgrep/toggles.lua
+++ b/lua/blink-ripgrep/toggles.lua
@@ -7,9 +7,9 @@ function toggles.init_once(config)
   if toggles.initialized then
     return
   end
-  assert(config.future_features.toggles)
+  assert(config.toggles)
 
-  local on_off = config.future_features.toggles.on_off
+  local on_off = config.toggles.on_off
   if not on_off then
     return
   end

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: 9.23.0
         version: 9.23.0
       '@tui-sandbox/library':
-        specifier: 10.0.0
-        version: 10.0.0(cypress@14.2.1)(prettier@3.5.3)(type-fest@4.38.0)(typescript@5.8.2)
+        specifier: 10.1.0
+        version: 10.1.0(cypress@14.2.1)(prettier@3.5.3)(type-fest@4.38.0)(typescript@5.8.2)
       '@types/node':
         specifier: 22.13.14
         version: 22.13.14
@@ -366,19 +366,19 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
-  '@trpc/client@11.0.0-rc.828':
-    resolution: {integrity: sha512-pV2bELnPqH7S2R1wBH6OB7lOi61ELt8CEcvHuxVM2YhL4hP408tzKT0YvNBo4GVqc8So/1ncpXJyRJQG0o6rsQ==}
+  '@trpc/client@11.0.1':
+    resolution: {integrity: sha512-HvOrvWAXbGBwt4om+NfuxrK4f+ik2aaNIXq7WLrJbEp7U+YXfh5++1a5p4JDaikrvSaObJ389DhYAGWz90xSGw==}
     peerDependencies:
-      '@trpc/server': 11.0.0-rc.828+322552736
+      '@trpc/server': 11.0.1
       typescript: '>=5.7.2'
 
-  '@trpc/server@11.0.0-rc.828':
-    resolution: {integrity: sha512-+dvcIcE5QPy52cz4rqwfUqk+WQDYAH3Xri+u2t0NdzIoo78fnL14if8oSZXAPU1bCmWGyR1k/0m5rSQ7AZaKlQ==}
+  '@trpc/server@11.0.1':
+    resolution: {integrity: sha512-DZS3+bONLno4oJjHBMrS3xRPtoZsnmBImDH/Mmo1QhaFt3Xp/S0Riu7WU/oofsLTVj2m1UO5LlgLJFumvlSNoQ==}
     peerDependencies:
       typescript: '>=5.7.2'
 
-  '@tui-sandbox/library@10.0.0':
-    resolution: {integrity: sha512-3yyrI354YirnW+WZHfs0Ma4aHhON8af/4IAeOkEn85rg41bgSI4TA+L5PgOzW1AkIOYcSeWPeZp8k02nOeOOiQ==}
+  '@tui-sandbox/library@10.1.0':
+    resolution: {integrity: sha512-PZ8fKh17wdicsvu5RYkJmKcTObsV5SWVNs31y08YGWjhhDO8E3o9KOVkvAwjCB5KqUlbmFbAFieDPajeGvNHMQ==}
     hasBin: true
     peerDependencies:
       cypress: ^13 || ^14
@@ -2799,20 +2799,20 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
-  '@trpc/client@11.0.0-rc.828(@trpc/server@11.0.0-rc.828(typescript@5.8.2))(typescript@5.8.2)':
+  '@trpc/client@11.0.1(@trpc/server@11.0.1(typescript@5.8.2))(typescript@5.8.2)':
     dependencies:
-      '@trpc/server': 11.0.0-rc.828(typescript@5.8.2)
+      '@trpc/server': 11.0.1(typescript@5.8.2)
       typescript: 5.8.2
 
-  '@trpc/server@11.0.0-rc.828(typescript@5.8.2)':
+  '@trpc/server@11.0.1(typescript@5.8.2)':
     dependencies:
       typescript: 5.8.2
 
-  '@tui-sandbox/library@10.0.0(cypress@14.2.1)(prettier@3.5.3)(type-fest@4.38.0)(typescript@5.8.2)':
+  '@tui-sandbox/library@10.1.0(cypress@14.2.1)(prettier@3.5.3)(type-fest@4.38.0)(typescript@5.8.2)':
     dependencies:
       '@catppuccin/palette': 1.7.1
-      '@trpc/client': 11.0.0-rc.828(@trpc/server@11.0.0-rc.828(typescript@5.8.2))(typescript@5.8.2)
-      '@trpc/server': 11.0.0-rc.828(typescript@5.8.2)
+      '@trpc/client': 11.0.1(@trpc/server@11.0.1(typescript@5.8.2))(typescript@5.8.2)
+      '@trpc/server': 11.0.1(typescript@5.8.2)
       '@xterm/addon-attach': 0.11.0(@xterm/xterm@5.5.0)
       '@xterm/addon-fit': 0.10.0(@xterm/xterm@5.5.0)
       '@xterm/xterm': 5.5.0


### PR DESCRIPTION
# feat: move toggle keymaps to stable features

Introduced in https://github.com/mikavilpas/blink-ripgrep.nvim/pull/123
and https://github.com/mikavilpas/blink-ripgrep.nvim/pull/127

# refactor: fix type-check failing on deprecated 0.11 API

https://github.com/mikavilpas/blink-ripgrep.nvim/actions/runs/14086700119/job/39452573012?pr=183

# test: disable video recording in cypress tests


