### PR TITLE
style: disable deprecation introduced by nvim 0.11.0 as stable

### DIFF
--- a/lua/blink-ripgrep/visualization.lua
+++ b/lua/blink-ripgrep/visualization.lua
@@ -17,6 +17,7 @@ function visualization.flash_search_prefix(prefix)
 
   local hlstart = cursor[2] - #prefix
   local hlend = cursor[2]
+  ---@diagnostic disable-next-line: deprecated
   vim.api.nvim_buf_add_highlight(
     0,
     ns_id,


### PR DESCRIPTION
We have e2e tests that will show if this breaks anything.