### PR TITLE
feat: add workaround for issue with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ return {
             -- You can enable these to try them out beforehand, but be aware
             -- that they might change. Nothing is enabled by default.
             future_features = {
+              -- Workaround for
+              -- https://github.com/mikavilpas/blink-ripgrep.nvim/issues/185. This
+              -- is a temporary fix and will be removed in the future.
+              issue185_workaround = false,
+
               -- Keymaps to toggle features on/off. This can be used to alter
               -- the behavior of the plugin without restarting Neovim. Nothing
               -- is enabled by default.

--- a/lua/blink-ripgrep/backends/git_grep/git_grep.lua
+++ b/lua/blink-ripgrep/backends/git_grep/git_grep.lua
@@ -90,6 +90,12 @@ function GitGrepBackend:get_matches(prefix, context, resolve)
             label = match.match.text,
             insertText = match.match.text,
           }
+
+          if self.config.future_features.issue185_workaround then
+            items[match.match.text].documentation.draw = nil
+            ---@diagnostic disable-next-line: inject-field
+            items[match.match.text].documentation.render = nil
+          end
         end
       end
 

--- a/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
+++ b/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
@@ -94,6 +94,12 @@ function RipgrepBackend:get_matches(prefix, context, resolve)
               label = match_text,
               insertText = match_text,
             }
+
+            if self.config.future_features.issue185_workaround then
+              items[match.match.text].documentation.draw = nil
+              ---@diagnostic disable-next-line: inject-field
+              items[match.match.text].documentation.render = nil
+            end
           end
         end
       end

--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -20,6 +20,7 @@
 ---@class blink-ripgrep.FutureFeatures
 ---@field toggles? blink-ripgrep.ToggleKeymaps # Keymaps to toggle features on/off. This can be used to alter the behavior of the plugin without restarting Neovim. Nothing is enabled by default.
 ---@field backend? blink-ripgrep.BackendConfig
+---@field issue185_workaround? boolean # Workaround for https://github.com/mikavilpas/blink-ripgrep.nvim/issues/185. This is a temporary fix and will be removed in the future.
 
 ---@class blink-ripgrep.BackendConfig
 ---@field use? blink-ripgrep.BackendSelection # The backend to use for searching. Defaults to "ripgrep". "gitgrep" is available as a preview right now.
@@ -65,6 +66,7 @@ RgSource.config = {
     backend = {
       use = "ripgrep",
     },
+    issue185_workaround = false,
   },
 }
 


### PR DESCRIPTION
This disables documentation rendering completely, but avoids errors like:

> Error: ...al/nvim-data/lazy/blink.cmp/lua/blink/cmp/fuzzy/init.lua:44: can't serialize object of type 6
> Nvim v0.11.0
> blink.cmp v1.0.0
> blink-ripgrep commit af61f99

https://github.com/mikavilpas/blink-ripgrep.nvim/issues/185