### PR TITLE
feat: remove issue185_workaround as it is no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,6 @@ return {
             -- You can enable these to try them out beforehand, but be aware
             -- that they might change. Nothing is enabled by default.
             future_features = {
-              -- Workaround for
-              -- https://github.com/mikavilpas/blink-ripgrep.nvim/issues/185. This
-              -- is a temporary fix and will be removed in the future.
-              issue185_workaround = false,
-
               backend = {
                 -- The backend to use for searching. Defaults to "ripgrep".
                 -- Available options:

--- a/lua/blink-ripgrep/backends/git_grep/git_grep.lua
+++ b/lua/blink-ripgrep/backends/git_grep/git_grep.lua
@@ -84,12 +84,6 @@ function GitGrepBackend:get_matches(prefix, context, resolve)
             label = match.match.text,
             insertText = match.match.text,
           }
-
-          if self.config.future_features.issue185_workaround then
-            items[match.match.text].documentation.draw = nil
-            ---@diagnostic disable-next-line: inject-field
-            items[match.match.text].documentation.render = nil
-          end
         end
       end
 

--- a/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
+++ b/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
@@ -94,12 +94,6 @@ function RipgrepBackend:get_matches(prefix, context, resolve)
               label = match_text,
               insertText = match_text,
             }
-
-            if self.config.future_features.issue185_workaround then
-              items[match.match.text].documentation.draw = nil
-              ---@diagnostic disable-next-line: inject-field
-              items[match.match.text].documentation.render = nil
-            end
           end
         end
       end

--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -20,7 +20,6 @@
 
 ---@class blink-ripgrep.FutureFeatures
 ---@field backend? blink-ripgrep.BackendConfig
----@field issue185_workaround? boolean # Workaround for https://github.com/mikavilpas/blink-ripgrep.nvim/issues/185. This is a temporary fix and will be removed in the future.
 
 ---@class blink-ripgrep.BackendConfig
 ---@field use? blink-ripgrep.BackendSelection # The backend to use for searching. Defaults to "ripgrep". "gitgrep" is available as a preview right now.
@@ -68,7 +67,6 @@ RgSource.config = {
     backend = {
       use = "ripgrep",
     },
-    issue185_workaround = false,
   },
 }
 


### PR DESCRIPTION
The issue has now been resolved in blink, so we can safely remove the workaround.

https://github.com/mikavilpas/blink-ripgrep.nvim/issues/185#issuecomment-2847654332