### PR TITLE
refactor: remove deprecated render function

### DIFF
--- a/lua/blink-ripgrep/backends/git_grep/git_grep.lua
+++ b/lua/blink-ripgrep/backends/git_grep/git_grep.lua
@@ -61,23 +61,18 @@ function GitGrepBackend:get_matches(prefix, context, resolve)
       local items = {}
       for _, file in pairs(output.files) do
         for _, match in pairs(file.matches) do
-          local draw_docs = function(draw_opts)
-            require("blink-ripgrep.documentation").render_item_documentation(
-              self.config,
-              draw_opts,
-              file,
-              match
-            )
-          end
-
           ---@diagnostic disable-next-line: missing-fields
           items[match.match.text] = {
             documentation = {
               kind = "markdown",
-              draw = draw_docs,
-              -- legacy, will be removed in a future release of blink
-              -- https://github.com/Saghen/blink.cmp/issues/1113
-              render = draw_docs,
+              draw = function(draw_opts)
+                require("blink-ripgrep.documentation").render_item_documentation(
+                  self.config,
+                  draw_opts,
+                  file,
+                  match
+                )
+              end,
             },
             source_id = "blink-ripgrep",
             kind = 1,

--- a/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
+++ b/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
@@ -71,23 +71,18 @@ function RipgrepBackend:get_matches(prefix, context, resolve)
           -- PERF: only register the match once - right now there is no useful
           -- way to display the same match multiple times
           if not items[match_text] then
-            local draw_docs = function(draw_opts)
-              require("blink-ripgrep.documentation").render_item_documentation(
-                self.config,
-                draw_opts,
-                file,
-                match
-              )
-            end
-
             ---@diagnostic disable-next-line: missing-fields
             items[match_text] = {
               documentation = {
                 kind = "markdown",
-                draw = draw_docs,
-                -- legacy, will be removed in a future release of blink
-                -- https://github.com/Saghen/blink.cmp/issues/1113
-                render = draw_docs,
+                draw = function(draw_opts)
+                  require("blink-ripgrep.documentation").render_item_documentation(
+                    self.config,
+                    draw_opts,
+                    file,
+                    match
+                  )
+                end,
               },
               source_id = "blink-ripgrep",
               kind = kinds.Text,


### PR DESCRIPTION
In https://github.com/Saghen/blink.cmp/issues/1113 (2025-25-02), the `render` function was deprecated in favor of the `draw` function.

The old `render` function was kept around to give users some time to upgrade, but it's been so long that it's time to remove it.