### PR TITLE
refactor: handle disabling with `source:enabled()`

### DIFF
--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -102,16 +102,21 @@ function RgSource.new(input_opts)
   return self
 end
 
-function RgSource:get_completions(context, resolve)
+function RgSource:enabled()
   if self.config.mode ~= "on" then
     if self.config.debug then
       local debug = require("blink-ripgrep.debug")
       debug.add_debug_message("mode is off, skipping the search")
       debug.add_debug_invocation({ "ignored-because-mode-is-off" })
     end
-    resolve()
-    return
+    return false
   end
+
+  return true
+end
+
+function RgSource:get_completions(context, resolve)
+  assert(self.config.mode ~= "off")
 
   ---@type blink-ripgrep.Backend | nil
   local backend


### PR DESCRIPTION
This accomplishes the same thing,
- but opts into having the blink framework handle the disabling, which might be useful in the future.
- is more in line with the other sources

https://cmp.saghen.dev/development/source-boilerplate.html