### PR TITLE
refactor: remove `context` field from `resolve()` calls

### DIFF
--- a/lua/blink-ripgrep/backends/git_grep/git_grep.lua
+++ b/lua/blink-ripgrep/backends/git_grep/git_grep.lua
@@ -10,7 +10,7 @@ function GitGrepBackend.new(config)
   return self --[[@as blink-ripgrep.GitGrepBackend]]
 end
 
-function GitGrepBackend:get_matches(prefix, context, resolve)
+function GitGrepBackend:get_matches(prefix, _, resolve)
   local command_module =
     require("blink-ripgrep.backends.git_grep.gitgrep_command")
 
@@ -89,7 +89,6 @@ function GitGrepBackend:get_matches(prefix, context, resolve)
           is_incomplete_forward = false,
           is_incomplete_backward = false,
           items = vim.tbl_values(items),
-          context = context,
         })
       end)
     end)

--- a/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
+++ b/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
@@ -8,7 +8,7 @@ function RipgrepBackend.new(config)
   return self --[[@as blink-ripgrep.RipgrepBackend]]
 end
 
-function RipgrepBackend:get_matches(prefix, context, resolve)
+function RipgrepBackend:get_matches(prefix, _, resolve)
   -- builtin default command
   local command_module =
     require("blink-ripgrep.backends.ripgrep.ripgrep_command")
@@ -100,7 +100,6 @@ function RipgrepBackend:get_matches(prefix, context, resolve)
           is_incomplete_forward = false,
           is_incomplete_backward = false,
           items = vim.tbl_values(items),
-          context = context,
         })
       end)
     end)


### PR DESCRIPTION
It's not present according to the types, which means it shouldn't be there.