### PR TITLE
feat(opt-in): toggle debug mode on/off for quick plugin debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,11 @@ return {
             -- is enabled by default. Requires folke/snacks.nvim.
             toggles = {
               -- The keymap to toggle the plugin on and off from blink
-              -- completion results. Example: "<leader>tg"
+              -- completion results. Example: "<leader>tg" ("toggle grep")
               on_off = nil,
+
+              -- The keymap to toggle debug mode on/off. Example: "<leader>td" ("toggle debug")
+              debug = nil,
             },
 
             -- Features that are not yet stable and might change in the future.

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -73,6 +73,7 @@ local plugins = {
               debug = true,
               toggles = {
                 on_off = "<leader>tg",
+                debug = "<leader>td",
               },
             },
           },

--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -30,7 +30,8 @@
 ---| "gitgrep" # Use git grep for searching. This is faster but only works in git repositories.
 
 ---@class blink-ripgrep.ToggleKeymaps
----@field on_off? string # The keymap to toggle the plugin on and off from blink completion results. Example: "<leader>tg"
+---@field on_off? string # The keymap to toggle the plugin on and off from blink completion results. Example: "<leader>tg" ("toggle grep")
+---@field debug? string # The keymap to toggle debug mode on/off. Example: "<leader>td" ("toggle debug")
 
 ---@alias blink-ripgrep.Mode
 ---| "on" # Show completions when triggered by blink

--- a/lua/blink-ripgrep/toggles.lua
+++ b/lua/blink-ripgrep/toggles.lua
@@ -9,27 +9,47 @@ function toggles.init_once(config)
   end
   assert(config.toggles)
 
-  local on_off = config.toggles.on_off
-  if not on_off then
-    return
+  local on_off_keymap = config.toggles.on_off
+  local debug_keymap = config.toggles.debug
+
+  if on_off_keymap then
+    require("snacks.toggle")
+      .new({
+        id = "blink-ripgrep-manual-mode",
+        name = "blink-ripgrep",
+        get = function()
+          return config.mode == "on"
+        end,
+        set = function(state)
+          if state then
+            config.mode = "on"
+          else
+            config.mode = "off"
+          end
+        end,
+      })
+      :map(on_off_keymap, { mode = { "n" } })
   end
 
-  require("snacks.toggle")
-    .new({
-      id = "blink-ripgrep-manual-mode",
-      name = "blink-ripgrep",
-      get = function()
-        return config.mode == "on"
-      end,
-      set = function(state)
-        if state then
-          config.mode = "on"
-        else
-          config.mode = "off"
-        end
-      end,
-    })
-    :map(on_off, { mode = { "n" } })
+  if debug_keymap then
+    require("snacks.toggle")
+      .new({
+        id = "blink-ripgrep-debug",
+        name = "blink-ripgrep-debug",
+        get = function()
+          return config.debug
+        end,
+        set = function(state)
+          if state then
+            config.debug = true
+          else
+            config.debug = false
+          end
+        end,
+      })
+      :map(debug_keymap, { mode = { "n" } })
+  end
+
   toggles.initialized = true
 end
 


### PR DESCRIPTION
# feat(opt-in): toggle debug mode on/off for quick plugin debugging

This is probably only useful for plugin developers.

I have had some visual issues come up occasionally. I typically don't
have time to investigate them, and I either forget to do it later when I
have time, or cannot reproduce them any longer.

This commit adds a toggle to turn debug mode on and off, so that I can
quickly enable it when I see a visual issue, and then disable it again
when I am done debugging.

