### PR TITLE
fix: hide any errors about highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ return {
         -- 👇🏻👇🏻 (optional) add a keymap to invoke the search manually
         ["<c-g>"] = {
           function()
-            -- invoke manually, requires blink >v0.8.0
             require("blink-cmp").show({ providers = { "ripgrep" } })
           end,
         },

--- a/lua/blink-ripgrep/documentation.lua
+++ b/lua/blink-ripgrep/documentation.lua
@@ -74,7 +74,8 @@ function documentation.render_item_documentation(config, draw_opts, file, match)
     bufnr,
     match,
     highlight_ns_id,
-    context_preview
+    context_preview,
+    config.debug
   )
 end
 

--- a/lua/blink-ripgrep/highlighting.lua
+++ b/lua/blink-ripgrep/highlighting.lua
@@ -7,11 +7,13 @@ local M = {}
 ---@param match blink-ripgrep.Match
 ---@param highlight_ns_id number
 ---@param context_preview blink-ripgrep.NumberedLine[]
+---@param debug boolean
 function M.highlight_match_in_doc_window(
   bufnr,
   match,
   highlight_ns_id,
-  context_preview
+  context_preview,
+  debug
 )
   ---@type number | nil
   local line_in_docs = nil
@@ -24,17 +26,26 @@ function M.highlight_match_in_doc_window(
 
   assert(line_in_docs, "missing line in docs")
 
-  -- highlight the word that matched in this context preview
-  vim.api.nvim_buf_set_extmark(
-    bufnr,
-    highlight_ns_id,
-    line_in_docs + 1,
-    match.start_col,
-    {
-      end_col = match.end_col,
-      hl_group = "BlinkRipgrepMatch",
-    }
-  )
+  local success = pcall(function()
+    -- highlight the word that matched in this context preview
+    vim.api.nvim_buf_set_extmark(
+      bufnr,
+      highlight_ns_id,
+      line_in_docs + 1,
+      match.start_col,
+      {
+        end_col = match.end_col,
+        hl_group = "BlinkRipgrepMatch",
+      }
+    )
+  end)
+
+  if debug and not success then
+    require("blink-ripgrep.debug").add_debug_message(
+      "Failed to highlight match in documentation window: "
+        .. vim.inspect(match)
+    )
+  end
 end
 
 return M


### PR DESCRIPTION
# fix: hide any errors about highlighting

Workaround for
https://github.com/mikavilpas/blink-ripgrep.nvim/issues/228

# docs: remove notice about blink >v0.8.0 requirement

It's so old now, everybody has a newer version of blink-cmp already.
It's just confusing at this point.

