### PR TITLE
refactor!: clearly support backend specific options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,25 +60,9 @@ return {
           ---@module "blink-ripgrep"
           ---@type blink-ripgrep.Options
           opts = {
-            -- For many options, see `rg --help` for an exact description of
-            -- the values that ripgrep expects.
-
             -- the minimum length of the current word to start searching
             -- (if the word is shorter than this, the search will not start)
             prefix_min_len = 3,
-
-            -- The number of lines to show around each match in the preview
-            -- (documentation) window. For example, 5 means to show 5 lines
-            -- before, then the match, and another 5 lines after the match.
-            context_size = 5,
-
-            -- The maximum file size of a file that ripgrep should include in
-            -- its search. Useful when your project contains large files that
-            -- might cause performance issues.
-            -- Examples:
-            -- "1024" (bytes by default), "200K", "1M", "1G", which will
-            -- exclude files larger than that size.
-            max_filesize = "1M",
 
             -- Specifies how to find the root of the project where the ripgrep
             -- search will start from. Accepts the same options as the marker
@@ -90,44 +74,10 @@ return {
             -- - { ".git", "package.json", ".root" }
             project_root_marker = ".git",
 
-            -- Enable fallback to neovim cwd if project_root_marker is not
-            -- found. Default: `true`, which means to use the cwd.
-            project_root_fallback = true,
-
-            -- The casing to use for the search in a format that ripgrep
-            -- accepts. Defaults to "--ignore-case". See `rg --help` for all the
-            -- available options ripgrep supports, but you can try
-            -- "--case-sensitive" or "--smart-case".
-            search_casing = "--ignore-case",
-
-            -- (advanced) Any additional options you want to give to ripgrep.
-            -- See `rg -h` for a list of all available options. Might be
-            -- helpful in adjusting performance in specific situations.
-            -- If you have an idea for a default, please open an issue!
-            --
-            -- Not everything will work (obviously).
-            additional_rg_options = {},
-
             -- When a result is found for a file whose filetype does not have a
             -- treesitter parser installed, fall back to regex based highlighting
             -- that is bundled in Neovim.
             fallback_to_regex_highlighting = true,
-
-            -- Absolute root paths where the rg command will not be executed.
-            -- Usually you want to exclude paths using gitignore files or
-            -- ripgrep specific ignore files, but this can be used to only
-            -- ignore the paths in blink-ripgrep.nvim, maintaining the ability
-            -- to use ripgrep for those paths on the command line. If you need
-            -- to find out where the searches are executed, enable `debug` and
-            -- look at `:messages`.
-            ignore_paths = {},
-
-            -- Any additional paths to search in, in addition to the project
-            -- root. This can be useful if you want to include dictionary files
-            -- (/usr/share/dict/words), framework documentation, or any other
-            -- reference material that is not available within the project
-            -- root.
-            additional_paths = {},
 
             -- Keymaps to toggle features on/off. This can be used to alter
             -- the behavior of the plugin without restarting Neovim. Nothing
@@ -141,22 +91,71 @@ return {
               debug = nil,
             },
 
-            -- Features that are not yet stable and might change in the future.
-            -- You can enable these to try them out beforehand, but be aware
-            -- that they might change. Nothing is enabled by default.
-            future_features = {
-              backend = {
-                -- The backend to use for searching. Defaults to "ripgrep".
-                -- Available options:
-                -- - "ripgrep", always use ripgrep
-                -- - "gitgrep", always use git grep
-                -- - "gitgrep-or-ripgrep", use git grep if possible, otherwise
-                --   ripgrep
-                use = "ripgrep",
-                -- Whether to set up custom highlight-groups for the icons used
-                -- in the completion items. Defaults to `true`, which means
-                -- this is enabled.
-                customize_icon_highlight = true,
+            backend = {
+              -- The backend to use for searching. Defaults to "ripgrep".
+              -- Available options:
+              -- - "ripgrep", always use ripgrep
+              -- - "gitgrep", always use git grep
+              -- - "gitgrep-or-ripgrep", use git grep if possible, otherwise
+              --   use ripgrep
+              use = "ripgrep",
+
+              -- Whether to set up custom highlight-groups for the icons used
+              -- in the completion items. Defaults to `true`, which means this
+              -- is enabled.
+              customize_icon_highlight = true,
+
+              ripgrep = {
+                -- For many options, see `rg --help` for an exact description of
+                -- the values that ripgrep expects.
+
+                -- The number of lines to show around each match in the preview
+                -- (documentation) window. For example, 5 means to show 5 lines
+                -- before, then the match, and another 5 lines after the match.
+                context_size = 5,
+
+                -- The maximum file size of a file that ripgrep should include
+                -- in its search. Useful when your project contains large files
+                -- that might cause performance issues.
+                -- Examples:
+                -- "1024" (bytes by default), "200K", "1M", "1G", which will
+                -- exclude files larger than that size.
+                max_filesize = "1M",
+
+                -- Enable fallback to neovim cwd if project_root_marker is not
+                -- found. Default: `true`, which means to use the cwd.
+                project_root_fallback = true,
+
+                -- The casing to use for the search in a format that ripgrep
+                -- accepts. Defaults to "--ignore-case". See `rg --help` for
+                -- all the available options ripgrep supports, but you can try
+                -- "--case-sensitive" or "--smart-case".
+                search_casing = "--ignore-case",
+
+                -- (advanced) Any additional options you want to give to
+                -- ripgrep. See `rg -h` for a list of all available options.
+                -- Might be helpful in adjusting performance in specific
+                -- situations. If you have an idea for a default, please open
+                -- an issue!
+                --
+                -- Not everything will work (obviously).
+                additional_rg_options = {},
+
+                -- Absolute root paths where the rg command will not be
+                -- executed. Usually you want to exclude paths using gitignore
+                -- files or ripgrep specific ignore files, but this can be used
+                -- to only ignore the paths in blink-ripgrep.nvim, maintaining
+                -- the ability to use ripgrep for those paths on the command
+                -- line. If you need to find out where the searches are
+                -- executed, enable `debug` and look at `:messages`.
+                ignore_paths = {},
+
+                -- Any additional paths to search in, in addition to the
+                -- project root. This can be useful if you want to include
+                -- dictionary files (/usr/share/dict/words), framework
+                -- documentation, or any other reference material that is not
+                -- available within the project root.
+                additional_paths = {},
               },
             },
 

--- a/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_spec.cy.ts
@@ -86,7 +86,7 @@ describe("the GitGrepBackend", () => {
     })
   })
 
-  it("can use an underscore (_) ca be used to trigger blink completions", () => {
+  it("can use an underscore (_) to trigger blink completions", () => {
     cy.visit("/")
     startNeovimWithGitBackend({}).then(() => {
       // wait until text on the start screen is visible

--- a/integration-tests/cypress/e2e/blink-ripgrep/searching-inside-projects.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/searching-inside-projects.cy.ts
@@ -64,7 +64,7 @@ describe("searching inside projects with the RipgrepBackend", () => {
 
       // make sure the preconditions for this case are met
       nvim.waitForLuaCode({
-        luaAssertion: `assert(require("blink-ripgrep").config.project_root_fallback == false)`,
+        luaAssertion: `assert(require("blink-ripgrep").config.backend.ripgrep.project_root_fallback == false)`,
       })
 
       // search for something that was found in the previous test (so we know

--- a/integration-tests/cypress/e2e/blink-ripgrep/utils/verifyGitGrepBackendWasUsedInTest.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/utils/verifyGitGrepBackendWasUsedInTest.ts
@@ -8,12 +8,10 @@ export function verifyCorrectBackendWasUsedInTest(
   }).then((result) => {
     assert(result.value)
     const config = z
-      .object({
-        future_features: z.object({ backend: z.object({ use: z.string() }) }),
-      })
+      .object({ backend: z.object({ use: z.string() }) })
       .safeParse(result.value)
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     expect(config.error).to.be.undefined
-    expect(config.data?.future_features.backend.use).to.equal(backend)
+    expect(config.data?.backend.use).to.equal(backend)
   })
 }

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -75,10 +75,8 @@ local plugins = {
                 on_off = "<leader>tg",
                 debug = "<leader>td",
               },
-              future_features = {
-                backend = {
-                  customize_icon_highlight = false,
-                },
+              backend = {
+                customize_icon_highlight = false,
               },
             },
           },

--- a/integration-tests/test-environment/config-modifications/apply_highlight_customization.lua
+++ b/integration-tests/test-environment/config-modifications/apply_highlight_customization.lua
@@ -1,6 +1,5 @@
 function Enable_customization()
-  require("blink-ripgrep").config.future_features.backend.customize_icon_highlight =
-    true
+  require("blink-ripgrep").config.backend.customize_icon_highlight = true
 end
 
 function Customize_highlights()

--- a/integration-tests/test-environment/config-modifications/disable_project_root_fallback.lua
+++ b/integration-tests/test-environment/config-modifications/disable_project_root_fallback.lua
@@ -1,3 +1,7 @@
 require("blink-ripgrep").setup({
-  project_root_fallback = false,
+  backend = {
+    ripgrep = {
+      project_root_fallback = false,
+    },
+  },
 })

--- a/integration-tests/test-environment/config-modifications/set_ignore_paths.lua
+++ b/integration-tests/test-environment/config-modifications/set_ignore_paths.lua
@@ -1,6 +1,10 @@
 ---@param paths string[]
 function _G.set_ignore_paths(paths)
   require("blink-ripgrep").setup({
-    ignore_paths = paths,
+    backend = {
+      ripgrep = {
+        ignore_paths = paths,
+      },
+    },
   })
 end

--- a/integration-tests/test-environment/config-modifications/use_additional_paths.lua
+++ b/integration-tests/test-environment/config-modifications/use_additional_paths.lua
@@ -4,5 +4,9 @@ local path = vim.fn.resolve(vim.env.HOME .. "/additional-words-dir/words.txt")
 assert(vim.fn.filereadable(path) == 1, path .. " is not readable")
 
 require("blink-ripgrep").setup({
-  additional_paths = { path },
+  backend = {
+    ripgrep = {
+      additional_paths = { path },
+    },
+  },
 })

--- a/integration-tests/test-environment/config-modifications/use_case_sensitive_search.lua
+++ b/integration-tests/test-environment/config-modifications/use_case_sensitive_search.lua
@@ -1,3 +1,7 @@
 require("blink-ripgrep").setup({
-  search_casing = "--smart-case",
+  backend = {
+    ripgrep = {
+      search_casing = "--smart-case",
+    },
+  },
 })

--- a/integration-tests/test-environment/config-modifications/use_gitgrep_backend.lua
+++ b/integration-tests/test-environment/config-modifications/use_gitgrep_backend.lua
@@ -1,7 +1,5 @@
 require("blink-ripgrep").setup({
-  future_features = {
-    backend = {
-      use = "gitgrep",
-    },
+  backend = {
+    use = "gitgrep",
   },
 })

--- a/integration-tests/test-environment/config-modifications/use_gitgrep_or_ripgrep_backend.lua
+++ b/integration-tests/test-environment/config-modifications/use_gitgrep_or_ripgrep_backend.lua
@@ -1,7 +1,5 @@
 require("blink-ripgrep").setup({
-  future_features = {
-    backend = {
-      use = "gitgrep-or-ripgrep",
-    },
+  backend = {
+    use = "gitgrep-or-ripgrep",
   },
 })

--- a/lua/blink-ripgrep/backends/git_grep/git_grep.lua
+++ b/lua/blink-ripgrep/backends/git_grep/git_grep.lua
@@ -105,7 +105,7 @@ function GitGrepBackend:get_matches(prefix, _, resolve)
             insertText = match.match.text,
           }
 
-          if self.config.future_features.backend.customize_icon_highlight then
+          if self.config.backend.customize_icon_highlight then
             items[match.match.text].kind_icon = "" -- git logo
             items[match.match.text].kind_hl = GitGrepBackend.hl_group_name
             items[match.match.text].kind_name = GitGrepBackend.kind_name

--- a/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
+++ b/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
@@ -49,7 +49,7 @@ function RipgrepBackend:get_matches(prefix, _, resolve)
     return
   end
 
-  if vim.tbl_contains(self.config.ignore_paths, cmd.root) then
+  if vim.tbl_contains(self.config.backend.ripgrep.ignore_paths, cmd.root) then
     if self.config.debug then
       local debug = require("blink-ripgrep.debug")
       debug.add_debug_message("skipping search in ignored path" .. cmd.root)
@@ -114,7 +114,7 @@ function RipgrepBackend:get_matches(prefix, _, resolve)
               insertText = match_text,
             }
 
-            if self.config.future_features.backend.customize_icon_highlight then
+            if self.config.backend.customize_icon_highlight then
               items[match_text].kind_icon = "" -- magnifying glass icon
               items[match_text].kind_hl = RipgrepBackend.hl_group_name
               items[match_text].kind_name = RipgrepBackend.kind_name

--- a/lua/blink-ripgrep/backends/ripgrep/ripgrep_command.lua
+++ b/lua/blink-ripgrep/backends/ripgrep/ripgrep_command.lua
@@ -15,11 +15,11 @@ function RipgrepCommand.get_command(prefix, options)
     "--no-config",
     "--json",
     "--word-regexp",
-    "--max-filesize=" .. options.max_filesize,
-    options.search_casing,
+    "--max-filesize=" .. options.backend.ripgrep.max_filesize,
+    options.backend.ripgrep.search_casing,
   }
 
-  for _, option in ipairs(options.additional_rg_options) do
+  for _, option in ipairs(options.backend.ripgrep.additional_rg_options) do
     table.insert(cmd, option)
   end
 
@@ -27,7 +27,7 @@ function RipgrepCommand.get_command(prefix, options)
   table.insert(cmd, prefix .. "[\\w_-]+")
 
   local root = vim.fs.root(0, options.project_root_marker)
-  if options.project_root_fallback then
+  if options.backend.ripgrep.project_root_fallback then
     root = root or vim.fn.getcwd()
   end
   if root == nil then
@@ -36,7 +36,9 @@ function RipgrepCommand.get_command(prefix, options)
   end
 
   table.insert(cmd, root)
-  for _, additional_root in ipairs(options.additional_paths or {}) do
+  for _, additional_root in
+    ipairs(options.backend.ripgrep.additional_paths or {})
+  do
     table.insert(cmd, additional_root)
   end
 

--- a/lua/blink-ripgrep/documentation.lua
+++ b/lua/blink-ripgrep/documentation.lua
@@ -29,7 +29,7 @@ function documentation.render_item_documentation(config, draw_opts, file, match)
   }
 
   local context_preview = documentation.get_match_context(
-    config.context_size,
+    config.backend.context_size,
     match.line_number,
     file.relative_to_cwd
   )

--- a/lua/blink-ripgrep/migrate_config.lua
+++ b/lua/blink-ripgrep/migrate_config.lua
@@ -1,0 +1,78 @@
+local M = {}
+
+---@param options blink-ripgrep.Options
+---@param new_options? blink-ripgrep.Options | blink-ripgrep.LegacyOptions
+function M.migrate_config(options, new_options)
+  options = vim.tbl_extend("force", {
+    backend = {
+      ripgrep = {},
+      gitgrep = {},
+    },
+  } --[[@as blink-ripgrep.Options]], options)
+
+  ---@type table<string,string>
+  local migrations = {}
+
+  ---@type blink-ripgrep.LegacyOptions | {}
+  ---@diagnostic disable-next-line: assign-type-mismatch
+  local legacy_options = new_options
+
+  if legacy_options.ignore_paths ~= nil then
+    options.backend.ripgrep.ignore_paths = legacy_options.ignore_paths
+    migrations.ignore_paths = "backend.ripgrep.ignore_paths"
+  end
+
+  if legacy_options.project_root_fallback ~= nil then
+    options.backend.ripgrep.project_root_fallback =
+      legacy_options.project_root_fallback
+    migrations.project_root_fallback = "backend.ripgrep.project_root_fallback"
+  end
+
+  if legacy_options.additional_paths ~= nil then
+    options.backend.ripgrep.additional_paths = legacy_options.additional_paths
+    migrations.additional_paths = "backend.ripgrep.additional_paths"
+  end
+
+  if legacy_options.search_casing ~= nil then
+    options.backend.ripgrep.search_casing = legacy_options.search_casing
+    migrations.search_casing = "backend.ripgrep.search_casing"
+  end
+
+  if legacy_options.max_filesize ~= nil then
+    options.backend.ripgrep.max_filesize = legacy_options.max_filesize
+    migrations.max_filesize = "backend.ripgrep.max_filesize"
+  end
+
+  if legacy_options.additional_rg_options ~= nil then
+    options.backend.ripgrep.additional_rg_options =
+      legacy_options.additional_rg_options
+    migrations.additional_rg_options = "backend.ripgrep.additional_rg_options"
+  end
+
+  if legacy_options.context_size ~= nil then
+    options.backend.context_size = legacy_options.context_size
+    migrations.context_size = "backend.context_size"
+  end
+
+  if
+    legacy_options.future_features and legacy_options.future_features.backend
+  then
+    if
+      legacy_options.future_features.backend.customize_icon_highlight ~= nil
+    then
+      options.backend.customize_icon_highlight =
+        legacy_options.future_features.backend.customize_icon_highlight
+      migrations["future_features.backend.customize_icon_highlight"] =
+        "backend.customize_icon_highlight"
+    end
+
+    if legacy_options.future_features.backend.use ~= nil then
+      options.backend.use = legacy_options.future_features.backend.use
+      migrations["future_features.backend.use"] = "backend.use"
+    end
+  end
+
+  return options, migrations
+end
+
+return M

--- a/lua/blink-ripgrep/types/legacy_options.lua
+++ b/lua/blink-ripgrep/types/legacy_options.lua
@@ -1,0 +1,25 @@
+--- The format for options that was used before separate backend configurations
+--- were introduced
+---@class blink-ripgrep.LegacyOptions
+---@field prefix_min_len? number # The minimum length of the current word to start searching (if the word is shorter than this, the search will not start)
+---@field get_command? fun(context: blink.cmp.Context, prefix: string): blink-ripgrep.RipgrepCommand | nil # Changing this might break things - if you need some customization, please open an issue 🙂
+---@field get_prefix? fun(context: blink.cmp.Context): string
+---@field context_size? number # The number of lines to show around each match in the preview (documentation) window. For example, 5 means to show 5 lines before, then the match, and another 5 lines after the match.
+---@field max_filesize? string # The maximum file size that ripgrep should include in its search. Examples: "1024" (bytes by default), "200K", "1M", "1G"
+---@field search_casing? string # The casing to use for the search in a format that ripgrep accepts. Defaults to "--ignore-case". See `rg --help` for all the available options ripgrep supports, but you can try "--case-sensitive" or "--smart-case".
+---@field additional_rg_options? string[] # (advanced) Any options you want to give to ripgrep. See `rg -h` for a list of all available options.
+---@field fallback_to_regex_highlighting? boolean # (default: true) When a result is found for a file whose filetype does not have a treesitter parser installed, fall back to regex based highlighting that is bundled in Neovim.
+---@field project_root_marker? unknown # Specifies how to find the root of the project where the ripgrep search will start from. Accepts the same options as the marker given to `:h vim.fs.root()` which offers many possibilities for configuration. Defaults to ".git".
+---@field project_root_fallback? boolean # Enable fallback to neovim cwd if project_root_marker is not found. Default: `true`, which means to use the cwd.
+---@field debug? boolean # Show debug information in `:messages` that can help in diagnosing issues with the plugin.
+---@field ignore_paths? string[] # Absolute root paths where the rg command will not be executed. Usually you want to exclude paths using gitignore files or ripgrep specific ignore files, but this can be used to only ignore the paths in blink-ripgrep.nvim, maintaining the ability to use ripgrep for those paths on the command line. If you need to find out where the searches are executed, enable `debug` and look at `:messages`.
+---@field additional_paths? string[] # Any additional paths to search in, in addition to the project root. This can be useful if you want to include dictionary files (/usr/share/dict/words), framework documentation, or any other reference material that is not available within the project root.
+---@field mode? blink-ripgrep.Mode # The mode to use for showing completions. Defaults to automatically showing suggestions.
+---@field future_features? blink-ripgrep.LegacyFutureFeatures # Features that are not yet stable and might change in the future. You can enable these to try them out beforehand, but be aware that they might change. Nothing is enabled by default.
+
+---@class blink-ripgrep.LegacyFutureFeatures
+---@field backend? blink-ripgrep.LegacyBackendConfig
+
+---@class blink-ripgrep.LegacyBackendConfig
+---@field customize_icon_highlight? boolean # Whether to set up custom highlight-groups for the icons used in the completion items. Defaults to `true`, which means this is enabled.
+---@field use? string # The backend to use for searching. Defaults to "ripgrep". "gitgrep" is available as a preview right now.

--- a/spec/blink-ripgrep/config_spec.lua
+++ b/spec/blink-ripgrep/config_spec.lua
@@ -1,0 +1,60 @@
+---@module "blink-ripgrep.types.legacy_options"
+
+local assert = require("luassert")
+local migrate_config = require("blink-ripgrep.migrate_config")
+
+describe("reading the configuration", function()
+  it("supports reading legacy options", function()
+    -- before GitGrepBackend was introduced, the plugin only contained options
+    -- for ripgrep at the top level of the configuration. After the
+    -- introduction of GitGrepBackend, it was decided to split the options
+    -- under a new structure that allowed different backends to have different
+    -- options.
+    --
+    -- This is useful because not all gitgrep options and ripgrep options are
+    -- the same.
+    --
+    -- To make the transition easier for users, the legacy options are
+    -- supported via this test. This allows for a non breaking change for some
+    -- time until the user is ready to migrate to the new structure.
+    ---@type blink-ripgrep.LegacyOptions
+    local legacy_options = {
+      additional_paths = { "/additional/path/" },
+      additional_rg_options = { "--foo", "--bar" },
+      context_size = 5,
+      prefix_min_len = 3,
+      mode = "on",
+      project_root_fallback = true,
+      fallback_to_regex_highlighting = true,
+      ignore_paths = { "node_modules" },
+      max_filesize = "3M",
+      project_root_marker = ".git",
+      search_casing = "--smart-case",
+      future_features = {
+        backend = {
+          use = "ripgrep",
+          customize_icon_highlight = true,
+        },
+      },
+    }
+
+    local config = migrate_config.migrate_config({}, legacy_options)
+
+    assert.same({
+      backend = {
+        use = "ripgrep",
+        customize_icon_highlight = true,
+        context_size = 5,
+        ripgrep = {
+          ignore_paths = { "node_modules" },
+          project_root_fallback = true,
+          additional_paths = { "/additional/path/" },
+          search_casing = "--smart-case",
+          max_filesize = "3M",
+          additional_rg_options = { "--foo", "--bar" },
+        },
+        gitgrep = {},
+      },
+    } --[[@as blink-ripgrep.Options]], config)
+  end)
+end)


### PR DESCRIPTION
# refactor!: clearly support backend specific options

**Issue:**

Currently, two backends are supported: `ripgrep` and `gitgrep` (a
fallback backend `gitgrep-or-ripgrep` is also available). These use
ripgrep (`rg`) and `git grep` respectively to search for matches.

However, the configuration options for these backends are not clearly
separated, leading to confusion about which options apply to which
backend.

**Solution:**

Move to a new configuration format that clearly separates the
configuration options for each backend.

```lua
-- old config format
RgSource.config = {
  prefix_min_len = 3,
  fallback_to_regex_highlighting = true,
  project_root_marker = ".git",

  context_size = 5,                -- moved to backend config
  max_filesize = "1M",             -- moved to backend.ripgrep config
  additional_rg_options = {},      -- moved to backend.ripgrep config
  search_casing = "--ignore-case", -- moved to backend.ripgrep config
  ignore_paths = {},               -- moved to backend.ripgrep config
  project_root_fallback = true,    -- moved to backend.ripgrep config
  additional_paths = {},           -- moved to backend.ripgrep config

  mode = "on",
  future_features = { -- future_features has been removed
    backend = { -- this is now part of the top-level config
      use = "ripgrep",
      customize_icon_highlight = true,
    },
  },
  toggles = { on_off = nil, },
}

-- new default config
RgSource.config = {
  prefix_min_len = 3,
  fallback_to_regex_highlighting = true,
  project_root_marker = ".git",
  mode = "on",
  backend = {
    use = "ripgrep",
    customize_icon_highlight = true,
    context_size = 5,
    ripgrep = {
      ignore_paths = {},
      additional_paths = {},
      project_root_fallback = true,
      search_casing = "--ignore-case",
      max_filesize = "1M",
      additional_rg_options = {},
    },
  },
}
```

This includes an automatic migration for existing configurations that
simply moves the old options to the new format. It shows a
`vim.notify_once()` notification to inform users about the migration,
and it also shows which configuration options need to be updated.

This means that existing configurations will continue to work, but I'll
eventually remove the automatic migration, so please migrate your
configuration to the new format.

