### PR TITLE
fix: make `kind_name` less technical

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -14,7 +14,7 @@
     "@catppuccin/palette": "1.7.1",
     "cypress": "14.5.3",
     "wait-on": "8.0.4",
-    "zod": "4.0.13"
+    "zod": "4.0.14"
   },
   "devDependencies": {
     "@eslint/js": "9.32.0",

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -101,6 +101,14 @@ local plugins = {
         ---@diagnostic disable-next-line: missing-fields
         menu = {
           max_height = 25,
+
+          draw = {
+            columns = {
+              { "kind_icon", "label", "label_description", gap = 1 },
+              { "kind", gap = 6 },
+              { "source_name", gap = 1 },
+            },
+          },
         },
       },
       keymap = {

--- a/lua/blink-ripgrep/backends/git_grep/git_grep.lua
+++ b/lua/blink-ripgrep/backends/git_grep/git_grep.lua
@@ -3,7 +3,7 @@
 ---@class blink-ripgrep.GitGrepBackend : blink-ripgrep.Backend
 local GitGrepBackend = {}
 
-GitGrepBackend.kind_name = "RipgrepGit"
+GitGrepBackend.kind_name = "Git"
 GitGrepBackend.hl_group_name = "BlinkCmpKindRipgrepGit"
 
 -- https://cmp.saghen.dev/configuration/appearance.html#highlight-groups

--- a/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
+++ b/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
@@ -1,7 +1,7 @@
 ---@class blink-ripgrep.RipgrepBackend : blink-ripgrep.Backend
 local RipgrepBackend = {}
 
-RipgrepBackend.kind_name = "RipgrepRipgrep"
+RipgrepBackend.kind_name = "Ripgrep"
 RipgrepBackend.hl_group_name = "BlinkCmpKindRipgrepRipgrep"
 
 ---@param config blink-ripgrep.Options

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,15 +36,15 @@ importers:
         specifier: 8.0.4
         version: 8.0.4
       zod:
-        specifier: 4.0.13
-        version: 4.0.13
+        specifier: 4.0.14
+        version: 4.0.14
     devDependencies:
       '@eslint/js':
         specifier: 9.32.0
         version: 9.32.0
       '@tui-sandbox/library':
         specifier: 11.2.0
-        version: 11.2.0(cypress@14.5.3)(prettier@3.6.2)(type-fest@4.41.0)(typescript@5.8.3)(zod@4.0.13)
+        version: 11.2.0(cypress@14.5.3)(prettier@3.6.2)(type-fest@4.41.0)(typescript@5.8.3)(zod@4.0.14)
       '@types/node':
         specifier: 24.1.0
         version: 24.1.0
@@ -2502,8 +2502,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.0.13:
-    resolution: {integrity: sha512-jv+zRxuZQxTrFHzxZ46ezL2FtnE+M4HIJHJEwLsZ7UjrXHltdG6HrxvqM0twoVCWxJiYf8WqKjAcjztegpkB+Q==}
+  zod@4.0.14:
+    resolution: {integrity: sha512-nGFJTnJN6cM2v9kXL+SOBq3AtjQby3Mv5ySGFof5UGRHrRioSJ5iG680cYNjE/yWk671nROcpPj4hAS8nyLhSw==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -2762,7 +2762,7 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  '@tui-sandbox/library@11.2.0(cypress@14.5.3)(prettier@3.6.2)(type-fest@4.41.0)(typescript@5.8.3)(zod@4.0.13)':
+  '@tui-sandbox/library@11.2.0(cypress@14.5.3)(prettier@3.6.2)(type-fest@4.41.0)(typescript@5.8.3)(zod@4.0.14)':
     dependencies:
       '@catppuccin/palette': 1.7.1
       '@trpc/client': 11.4.3(@trpc/server@11.4.3(typescript@5.8.3))(typescript@5.8.3)
@@ -2782,7 +2782,7 @@ snapshots:
       type-fest: 4.41.0
       typescript: 5.8.3
       winston: 3.17.0
-      zod: 4.0.13
+      zod: 4.0.14
     transitivePeerDependencies:
       - supports-color
 
@@ -5254,6 +5254,6 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.0.13: {}
+  zod@4.0.14: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
# fix: make `kind_name` less technical

It's confusing for users to see `RipgrepGit` and `RipgrepRipgrep` as
kind names. This commit renames them to `Git` and `Ripgrep`
respectively.

Closes https://github.com/mikavilpas/blink-ripgrep.nvim/issues/265

# test: draw more details in completion menu items

This makes it easier to see if they change, or if they look weird.

