### PR TITLE
Test improvements

### DIFF
--- a/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_or_ripgrep_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_or_ripgrep_spec.cy.ts
@@ -39,8 +39,8 @@ describe("the GitGrepOrRipgrepBackend", () => {
       cy.typeIntoTerminal("234")
     })
   })
-})
 
-afterEach(() => {
-  verifyCorrectBackendWasUsedInTest("gitgrep-or-ripgrep")
+  afterEach(() => {
+    verifyCorrectBackendWasUsedInTest("gitgrep-or-ripgrep")
+  })
 })

--- a/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_spec.cy.ts
@@ -3,7 +3,10 @@ import { rgbify } from "@tui-sandbox/library/dist/src/client/color-utilities"
 import type { NeovimContext } from "cypress/support/tui-sandbox"
 import { assertMatchVisible } from "./utils/assertMatchVisible"
 import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope"
-import { textIsVisibleWithColor } from "./utils/textIsVisibleWithColor"
+import {
+  textIsVisibleWithBackgroundColor,
+  textIsVisibleWithColor,
+} from "./utils/textIsVisibleWithColor"
 import { verifyCorrectBackendWasUsedInTest } from "./utils/verifyGitGrepBackendWasUsedInTest"
 
 export type CatppuccinRgb = (typeof flavors.macchiato.colors)["surface0"]["rgb"]
@@ -258,10 +261,9 @@ describe("in debug mode", () => {
         // If the plugin works, this text should show up as a suggestion.
         cy.typeIntoTerminal("hip")
         // the search should have been started for the prefix "hip"
-        cy.contains("hip").should(
-          "have.css",
-          "backgroundColor",
-          rgbify(flavors.macchiato.colors.flamingo.rgb),
+        textIsVisibleWithBackgroundColor(
+          "hip",
+          flavors.macchiato.colors.flamingo.rgb,
         )
         //
         // blink is now in the Fuzzy(3) stage, and additional keypresses must not
@@ -272,10 +274,9 @@ describe("in debug mode", () => {
         cy.typeIntoTerminal("234")
 
         // wait for the highlight to disappear to test that too
-        cy.contains("hip").should(
-          "have.css",
-          "backgroundColor",
-          rgbify(flavors.macchiato.colors.base.rgb),
+        textIsVisibleWithBackgroundColor(
+          "hip",
+          flavors.macchiato.colors.base.rgb,
         )
 
         nvim

--- a/integration-tests/cypress/e2e/blink-ripgrep/backend_ripgrep_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/backend_ripgrep_spec.cy.ts
@@ -2,7 +2,10 @@ import { flavors } from "@catppuccin/palette"
 import { rgbify } from "@tui-sandbox/library/dist/src/client/color-utilities"
 import { assertMatchVisible } from "./utils/assertMatchVisible"
 import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope"
-import { textIsVisibleWithColor } from "./utils/textIsVisibleWithColor"
+import {
+  textIsVisibleWithBackgroundColor,
+  textIsVisibleWithColor,
+} from "./utils/textIsVisibleWithColor"
 
 describe("the RipgrepBackend", () => {
   it("shows words in other files as suggestions", () => {
@@ -258,10 +261,9 @@ describe("in debug mode", () => {
         // If the plugin works, this text should show up as a suggestion.
         cy.typeIntoTerminal("hip")
         // the search should have been started for the prefix "hip"
-        cy.contains("hip").should(
-          "have.css",
-          "backgroundColor",
-          rgbify(flavors.macchiato.colors.flamingo.rgb),
+        textIsVisibleWithBackgroundColor(
+          "hip",
+          flavors.macchiato.colors.flamingo.rgb,
         )
         //
         // blink is now in the Fuzzy(3) stage, and additional keypresses must not
@@ -272,10 +274,9 @@ describe("in debug mode", () => {
         cy.typeIntoTerminal("234")
 
         // wait for the highlight to disappear to test that too
-        cy.contains("hip").should(
-          "have.css",
-          "backgroundColor",
-          rgbify(flavors.macchiato.colors.base.rgb),
+        textIsVisibleWithBackgroundColor(
+          "hip",
+          flavors.macchiato.colors.base.rgb,
         )
 
         nvim

--- a/integration-tests/cypress/e2e/blink-ripgrep/utils/textIsVisibleWithColor.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/utils/textIsVisibleWithColor.ts
@@ -8,7 +8,6 @@ import type { CatppuccinRgb } from "../backend_gitgrep_spec.cy"
  * by the text we are looking for. Then we can check if the background
  * color of the element is the same as the one we are looking for.
  */
-
 export function textIsVisibleWithColor(
   text: string,
   color: CatppuccinRgb,
@@ -18,6 +17,24 @@ export function textIsVisibleWithColor(
 
     const colors = matching.map((_, el) => {
       return window.getComputedStyle(el).color
+    })
+
+    expect(JSON.stringify(colors.toArray())).to.contain(rgbify(color))
+  })
+}
+
+/** Like `textIsVisibleWithColor`, but checks the background color instead
+ * of the text color.
+ */
+export function textIsVisibleWithBackgroundColor(
+  text: string,
+  color: CatppuccinRgb,
+): Cypress.Chainable<JQuery> {
+  return cy.get("div.xterm-rows span").and(($spans) => {
+    const matching = $spans.filter((_, el) => !!el.textContent.includes(text))
+
+    const colors = matching.map((_, el) => {
+      return window.getComputedStyle(el).backgroundColor
     })
 
     expect(JSON.stringify(colors.toArray())).to.contain(rgbify(color))


### PR DESCRIPTION
# test: create a `textIsVisibleWithBackgroundColor` helper fn

# test: fix `verifyCorrectBackendWasUsedInTest` breaking interactively

Apparently it does not cause issues when running all tests headlessly,
which is done in ci.

