### PR TITLE
feat: support multiple matches on the same line in ripgrep backend

### DIFF
--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -66,6 +66,10 @@ export const MyTestDirectorySchema = z.object({
           name: z.literal("customize_highlight_colors.lua"),
           type: z.literal("file"),
         }),
+        "disable_buffer_words_source.lua": z.object({
+          name: z.literal("disable_buffer_words_source.lua"),
+          type: z.literal("file"),
+        }),
         "don't_use_debug_mode.lua": z.object({
           name: z.literal("don't_use_debug_mode.lua"),
           type: z.literal("file"),
@@ -172,6 +176,10 @@ export const MyTestDirectorySchema = z.object({
       name: z.literal("other-file.lua"),
       type: z.literal("file"),
     }),
+    "two-matches-on-same-line-file.txt": z.object({
+      name: z.literal("two-matches-on-same-line-file.txt"),
+      type: z.literal("file"),
+    }),
   }),
 })
 
@@ -194,6 +202,7 @@ export const testDirectoryFiles = z.enum([
   "additional-words-dir/words.txt",
   "additional-words-dir",
   "config-modifications/customize_highlight_colors.lua",
+  "config-modifications/disable_buffer_words_source.lua",
   "config-modifications/don't_use_debug_mode.lua",
   "config-modifications/enable_customize_icon_highlight.lua",
   "config-modifications/ripgrep/disable_project_root_fallback.lua",
@@ -219,6 +228,7 @@ export const testDirectoryFiles = z.enum([
   "limited",
   "line-file.lua",
   "other-file.lua",
+  "two-matches-on-same-line-file.txt",
   ".",
 ])
 export type MyTestDirectoryFile = z.infer<typeof testDirectoryFiles>

--- a/integration-tests/cypress/e2e/blink-ripgrep/backend_ripgrep_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/backend_ripgrep_spec.cy.ts
@@ -5,6 +5,7 @@ import {
   textIsVisibleWithColor,
 } from "@tui-sandbox/library/dist/src/client/cypress-assertions"
 import { assertMatchVisible } from "./utils/assertMatchVisible"
+import { textIsVisibleWithColors } from "./utils/color-utils"
 import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope"
 
 describe("the RipgrepBackend", () => {
@@ -180,6 +181,45 @@ describe("the RipgrepBackend", () => {
       textIsVisibleWithColor(
         icon,
         rgbify(flavors.macchiato.colors.flamingo.rgb),
+      )
+    })
+  })
+
+  it("highlights multiple matches on the same line correctly", () => {
+    // https://github.com/mikavilpas/blink-ripgrep.nvim/issues/228
+    cy.visit("/")
+    cy.startNeovim({
+      startupScriptModifications: ["disable_buffer_words_source.lua"],
+    }).then(() => {
+      // wait until text on the start screen is visible
+      cy.contains("If you see this text, Neovim is ready!")
+      createGitReposToLimitSearchScope()
+
+      // go to the end and start inserting on a new line
+      cy.typeIntoTerminal("Go")
+
+      // check the match "banana_with_text"
+      cy.typeIntoTerminal("ban")
+      cy.contains("banana_with_text") // wait for blink to show up results
+      cy.typeIntoTerminal("w") // narrow down the results to banana_with_text only
+
+      textIsVisibleWithColors(
+        "banana_with_text",
+        rgbify(flavors.macchiato.colors.base.rgb),
+        rgbify(flavors.macchiato.colors.mauve.rgb),
+      )
+
+      // check the other match, "banana"
+      cy.typeIntoTerminal("{backspace}ana")
+      textIsVisibleWithColors(
+        "banana",
+        rgbify(flavors.macchiato.colors.base.rgb),
+        rgbify(flavors.macchiato.colors.mauve.rgb),
+      )
+      textIsVisibleWithColors(
+        "banana_with_text",
+        rgbify(flavors.macchiato.colors.text.rgb),
+        rgbify(flavors.macchiato.colors.mantle.rgb),
       )
     })
   })

--- a/integration-tests/cypress/e2e/blink-ripgrep/utils/color-utils.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/utils/color-utils.ts
@@ -1,0 +1,13 @@
+import {
+  textIsVisibleWithBackgroundColor,
+  textIsVisibleWithColor,
+} from "@tui-sandbox/library/dist/src/client/cypress-assertions"
+
+export function textIsVisibleWithColors(
+  text: string,
+  foregroundColor: string,
+  backgroundColor: string,
+): void {
+  textIsVisibleWithColor(text, foregroundColor)
+  textIsVisibleWithBackgroundColor(text, backgroundColor)
+}

--- a/integration-tests/test-environment/config-modifications/disable_buffer_words_source.lua
+++ b/integration-tests/test-environment/config-modifications/disable_buffer_words_source.lua
@@ -1,0 +1,2 @@
+local blink_config = require("blink.cmp.config")
+blink_config.sources.default = { "ripgrep" }

--- a/integration-tests/test-environment/two-matches-on-same-line-file.txt
+++ b/integration-tests/test-environment/two-matches-on-same-line-file.txt
@@ -1,0 +1,1 @@
+banana  banana_with_text

--- a/lua/blink-ripgrep/backends/ripgrep/ripgrep_parser.lua
+++ b/lua/blink-ripgrep/backends/ripgrep/ripgrep_parser.lua
@@ -63,15 +63,16 @@ function M.parse(ripgrep_output, cwd)
       elseif json.type == "match" then
         local file, line_number = get_file_context(json, output)
 
-        local text = json.data.submatches[1].match.text
-
-        if not file.matches[text] then
-          file.matches[text] = {
-            start_col = json.data.submatches[1].start,
-            end_col = json.data.submatches[1]["end"],
-            match = { text = text },
-            line_number = line_number,
-          }
+        for _, submatch in ipairs(json.data.submatches) do
+          local text = submatch.match.text
+          if not file.matches[text] then
+            file.matches[text] = {
+              start_col = submatch.start,
+              end_col = submatch["end"],
+              match = { text = text },
+              line_number = line_number,
+            }
+          end
         end
       end
     end


### PR DESCRIPTION
**Issue:**

When using the ripgrep backend to match a line like the following with a query like "ban" that matches both "banana" and "banana_with_text", only "banana" is reported as a match, and banana_with_text is ignored completely:

```text
banana  banana_with_text
```

Looks like I had forgotten to implement this in the ripgrep parser.

**Solution:**

Implement it! Now we report both matches as results like you would expect.