### PR TITLE
refactor: remove `prefix` from git_grep and ripgrep files as unused

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,3 +60,4 @@ jobs:
           name: cypress-screenshots
           path: integration-tests/cypress/screenshots
           if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
+          overwrite: true # defaults to `false`, set to `true` to overwrite existing artifacts with the same name

--- a/lua/blink-ripgrep/backends/git_grep/git_grep.lua
+++ b/lua/blink-ripgrep/backends/git_grep/git_grep.lua
@@ -80,7 +80,7 @@ function GitGrepBackend:get_matches(prefix, _, resolve)
 
       local lines = vim.split(result.stdout, "\n")
       local parser = require("blink-ripgrep.backends.git_grep.git_grep_parser")
-      local output = parser.parse_output(prefix, lines, cwd)
+      local output = parser.parse_output(lines, cwd)
 
       ---@type table<string, blink.cmp.CompletionItem>
       local items = {}

--- a/lua/blink-ripgrep/backends/git_grep/git_grep_parser.lua
+++ b/lua/blink-ripgrep/backends/git_grep/git_grep_parser.lua
@@ -6,16 +6,14 @@ local GitGrepParser = {}
 ---@field files table<string, blink-ripgrep.GitgrepFile>
 
 ---@class(exact) blink-ripgrep.GitgrepFile
----@field prefix string the prefix that started the search
 ---@field type "gitgrep"
 ---@field language string the treesitter language of the file, used to determine what grammar to highlight the preview with
 ---@field matches table<string,blink-ripgrep.Match>
 ---@field relative_to_cwd string the relative path of the file to the current working directory
 
----@param prefix string
 ---@param lines string[]
 ---@param cwd string
-function GitGrepParser.parse_output(prefix, lines, cwd)
+function GitGrepParser.parse_output(lines, cwd)
   ---@type blink-ripgrep.GitgrepOutput
   local output = { files = {} }
 
@@ -47,7 +45,6 @@ function GitGrepParser.parse_output(prefix, lines, cwd)
           or ext
 
         file = {
-          prefix = prefix,
           type = "gitgrep",
           language = language,
           matches = {},

--- a/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
+++ b/lua/blink-ripgrep/backends/ripgrep/ripgrep.lua
@@ -81,7 +81,6 @@ function RipgrepBackend:get_matches(prefix, _, resolve)
 
       local parsed =
         require("blink-ripgrep.backends.ripgrep.ripgrep_parser").parse(
-          prefix,
           lines,
           cwd
         )

--- a/lua/blink-ripgrep/backends/ripgrep/ripgrep_parser.lua
+++ b/lua/blink-ripgrep/backends/ripgrep/ripgrep_parser.lua
@@ -4,7 +4,6 @@ local M = {}
 ---@field files table<string, blink-ripgrep.RipgrepFile>
 
 ---@class blink-ripgrep.RipgrepFile
----@field prefix string the prefix that started the search
 ---@field type "ripgrep"
 ---@field language string the treesitter language of the file, used to determine what grammar to highlight the preview with
 ---@field matches table<string,blink-ripgrep.Match>
@@ -32,10 +31,9 @@ end
 -- surrounding each match.
 -- This function converts the jsonl stream into a table.
 --
----@param prefix string
 ---@param ripgrep_output string[] ripgrep output in jsonl format
 ---@param cwd string the current working directory
-function M.parse(prefix, ripgrep_output, cwd)
+function M.parse(ripgrep_output, cwd)
   ---@type blink-ripgrep.RipgrepOutput
   local output = { files = {} }
 
@@ -59,7 +57,6 @@ function M.parse(prefix, ripgrep_output, cwd)
           or ext
 
         output.files[filename] = {
-          prefix = prefix,
           type = "ripgrep",
           language = language,
           matches = {},


### PR DESCRIPTION
# ci: don't crash the build if upload-artifact fails

https://github.com/actions/upload-artifact/blob/de65e23aa2b7e23d713bb51fbfcb6d502f8667d8/README.md?plain=1#L125

# refactor: remove `prefix` from git_grep and ripgrep files as unused

Closes https://github.com/mikavilpas/blink-ripgrep.nvim/issues/278

