### PR TITLE
Release please fixes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 integration-tests/dist/
 pnpm-lock.yaml
 .repro
+./CHANGELOG.md

--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -48,6 +48,8 @@
 local RgSource = {}
 RgSource.__index = RgSource
 
+RgSource.version = "1.0.0" -- x-release-please-version
+
 ---@type blink-ripgrep.Options
 RgSource.config = {
   prefix_min_len = 3,


### PR DESCRIPTION
# chore: save current version of plugin in source code

release-please keeps this up to date automatically.

# chore: prettier ignores CHANGELOG.md

Release-As: 1.0.0

