### PR TITLE
Automerge dependabot prs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,3 +61,21 @@ jobs:
           path: integration-tests/cypress/screenshots
           if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
           overwrite: true # defaults to `false`, set to `true` to overwrite existing artifacts with the same name
+
+  automerge:
+    needs: build
+    name: Automerge Dependabot PRs
+    runs-on: ubuntu-latest
+    permissions:
+      # NOTE: no special token needs to be generated if these permissions are
+      # used. However, "Workflow permissions > Allow GitHub Actions to create
+      # and approve pull requests" needs to be enabled under
+      # github.com/user/repo/settings/actions
+      # https://github.com/fastify/github-action-merge-dependabot/issues/359
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v3.11.1
+        with:
+          # https://github.com/fastify/github-action-merge-dependabot?tab=readme-ov-file
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -93,7 +93,10 @@ Example for [lazy.nvim](https://lazy.folke.io/):
 return {
   "saghen/blink.cmp",
   dependencies = {
-    "mikavilpas/blink-ripgrep.nvim",
+    {
+      "mikavilpas/blink-ripgrep.nvim",
+      version = "*", -- use the latest stable version
+    },
     -- 👆🏻👆🏻 add the dependency here
 
     -- optional dependency used for toggling features on/off


### PR DESCRIPTION
# docs: readme recommends using stable versions

Using the bleeding edge version (newest commit) can still be done
without specifying `version = "*"`, but the bleeding edge will start to
have more frequent changes due to the automerging of Dependabot PRs.

These changes don't have an effect on users (they only concern
end-to-end testing the plugin), but it might be disturbing to see
constant changes in the plugin manager.

For this reason, it's now recommended to use the latest stable version
by specifying `version = "*"`.

# ci: automerge Dependabot PRs when tests pass

