### PR TITLE
docs: reorganize the readme to display "How it works" at the end

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,23 +256,6 @@ return {
 
 </details>
 
-## 🤔 How it works
-
-When you enter insert mode and start typing a word, blink triggers a search with
-blink-ripgrep. Only one search is done to save resources. After getting the
-results, the following keys are used to filter the results.
-
-In this demo (using the option `debug = true` above), we can see the search
-starting when the word flashes with a different color. Notice how the word only
-flashes once:
-
-<!-- TODO add a better demo -->
-
-<https://github.com/user-attachments/assets/0651ad24-0403-4ab9-81ff-59b152283593>
-
-This is described in much more detail in blink's
-[architecture documentation](https://cmp.saghen.dev/development/architecture.html).
-
 ## 🏁 Performance
 
 Generally performance is very good, but depending on the size of your project
@@ -339,3 +322,20 @@ The plugin uses the following highlight groups to style the results:
 
 - `BlinkCmpKindRipgrepRipgrep` - the color of the icon used for ripgrep results
 - `BlinkCmpKindRipgrepGit` - the color of the icon used for git grep results
+
+## 🤔 How it works
+
+When you enter insert mode and start typing a word, blink triggers a search with
+blink-ripgrep. Only one search is done to save resources. After getting the
+results, the following keys are used to filter the results.
+
+In this demo (using the option `debug = true` above), we can see the search
+starting when the word flashes with a different color. Notice how the word only
+flashes once:
+
+<!-- TODO add a better demo -->
+
+<https://github.com/user-attachments/assets/0651ad24-0403-4ab9-81ff-59b152283593>
+
+This is described in much more detail in blink's
+[architecture documentation](https://cmp.saghen.dev/development/architecture.html).


### PR DESCRIPTION
Being deep and technical documentation, it can only be understood after you are quite familiar with the plugin. It's not what anyone wants to read at first, if at all.