### PR TITLE
docs: recommend pinning to `version = "*"` to avoid frequent updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ Example for [lazy.nvim](https://lazy.folke.io/):
 return {
   "saghen/blink.cmp",
   dependencies = {
-    "mikavilpas/blink-ripgrep.nvim",
+    {
+      "mikavilpas/blink-ripgrep.nvim",
+      version = "*", -- use the latest stable version
+    }
     -- 👆🏻👆🏻 add the dependency here
   },
   ---@module 'blink.cmp'


### PR DESCRIPTION
Dev and testing dependencies of the plugin are updated frequently. This does not benefit end users at all, so recommend pinning to the latest stable version instead. It can get annoying to get a useless update every day.