### PR TITLE
test: fix not being able to run tests locally

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -15,6 +15,7 @@
     "@eslint/js": "9.37.0",
     "@tui-sandbox/library": "11.9.1",
     "@types/node": "24.7.2",
+    "concurrently": "9.2.1",
     "cypress": "15.4.0",
     "eslint": "9.37.0",
     "eslint-config-prettier": "10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@types/node':
         specifier: 24.7.2
         version: 24.7.2
+      concurrently:
+        specifier: 9.2.1
+        version: 9.2.1
       cypress:
         specifier: 15.4.0
         version: 15.4.0


### PR DESCRIPTION
In
https://github.com/mikavilpas/blink-ripgrep.nvim/commit/fe14eafbe8445b4acb8a44ed7664634dc448d492 I had removed the `concurrently` package. It produced this error when trying to run `pnpm i && pnpm dev`

```sh
sh: concurrently: command not found
/Users/mikavilpas/git/blink-ripgrep.nvim/integration-tests:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @blink-ripgrep.nvim/integration-tests@0.0.0 dev: `pnpm tui neovim prepare && concurrently --kill-others --names 'app,cypress' --prefix-colors 'blue,yellow' 'pnpm tui start' 'pnpm cy:open --e2e --browser=electron > /dev/null 2>&1'`
spawn ENOENT
 ELIFECYCLE  Command failed with exit code 1.
```