### PR TITLE
chore(mise): disable idiomatic version files

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,5 @@
+settings.idiomatic_version_file_enable_tools = []
+
 [tools]
 "ubi:BurntSushi/ripgrep" = { version = "14.1.1", exe = "rg" }
 lua = "5.1"


### PR DESCRIPTION
https://github.com/mikavilpas/blink-ripgrep.nvim/actions/runs/18553082485/job/52884275335#step:11:17

> mise WARN deprecated [idiomatic_version_file_enable_tools]:
>
> Idiomatic version files like
> ~/work/blink-ripgrep.nvim/blink-ripgrep.nvim/.nvmrc are currently
> enabled by default. However, this will change in mise 2025.10.0 to
> instead default to disabled.
>
> You can remove this warning by explicitly enabling idiomatic version
> files for node with:
>
>     mise settings add idiomatic_version_file_enable_tools node
>
> You can disable idiomatic version files with:
>
>     mise settings add idiomatic_version_file_enable_tools "[]"
>
> See https://github.com/jdx/mise/discussions/4345 for more information.