### PR TITLE
feat: allow passing `additional_gitgrep_options` to git-grep backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,9 @@ return {
             },
 
             gitgrep = {
-              -- no options are currently available
+              -- Any extra options you want to give to git grep. Can be used to
+              -- e.g. exclude some files from the search.
+              additional_gitgrep_options = {}
             },
 
             -- Show debug information in `:messages` that can help in
@@ -278,11 +280,14 @@ few things you can do to improve performance:
 - Set the `debug = true` option, which will log debug information to your
   `:messages` in Neovim. You can copy paste these commands to your terminal and
   try to figure out why the search is slow.
-- Use ripgrep's extensive options to exclude/include files
-  ([ripgrep docs](https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#automatic-filtering))
+- Use the search backend's options to exclude/include files
   - ripgrep supports global as well as project/directory specific ignore files.
     By default, it uses `.gitignore`, `.git/info/exclude`, `.ignore`, and
-    `.rgignore` files.
+    `.rgignore` files
+    ([ripgrep docs](https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#automatic-filtering))
+  - git grep can be configured to ignore files using `.gitattributes` files. See
+    [documentation/ignore-files-from-git-grep.md](documentation/ignore-files-from-git-grep.md)
+    for more information.
 
 - If you still experience performance issues, please open an issue for
   discussion.

--- a/documentation/ignore-files-from-git-grep.md
+++ b/documentation/ignore-files-from-git-grep.md
@@ -1,0 +1,46 @@
+# Tutorial: ignoring Files from `git grep`
+
+> As a developer, when using `git grep` to search through my codebase, I want to
+> ignore certain files or directories.
+>
+> Maybe they contain non-useful information that still needs to be tracked with
+> git, or maybe the files are too large and slow down the search.
+
+git-grep can be configured to respect `.gitattributes` files for ignoring files.
+To do it, follow these steps:
+
+1. Create or edit a `.gitattributes` file in the root of your git repository.
+   Add patterns for the files/directories you want to ignore. Example:
+
+   ```gitattributes
+   # ignore the following from blink-ripgrep by giving them a specific attribute
+   # that we then ignore in the git grep command.
+   #
+   # The name of the attribute does not matter and can be chosen by the user.
+   subproject/file2.lua blink-ripgrep-ignore
+   ```
+
+2. Configure `blink-ripgrep` to pass the appropriate options to `git grep` to
+   ignore files with the specified attribute:
+
+   ```lua
+   require("blink-ripgrep").setup({
+     backend = {
+       gitgrep = {
+         additional_gitgrep_options = {
+           -- exclude files marked with the 'blink-ripgrep-ignore' attribute in
+           -- .gitattributes
+           ":(exclude,attr:blink-ripgrep-ignore)",
+         },
+       },
+     },
+   })
+   ```
+
+## Resources
+
+- <https://git-scm.com/docs/git-grep#Documentation/git-grep.txt-pathspec>
+- <https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-pathspec>
+- tests
+  - [test gitattributes configuration](../integration-tests/test-environment/config-modifications/gitgrep/ignore_files_with_gitattributes.lua)
+  - [test gitattributes](../integration-tests/test-environment/limited/.gitattributes)

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -78,6 +78,16 @@ export const MyTestDirectorySchema = z.object({
           name: z.literal("enable_customize_icon_highlight.lua"),
           type: z.literal("file"),
         }),
+        gitgrep: z.object({
+          name: z.literal("gitgrep/"),
+          type: z.literal("directory"),
+          contents: z.object({
+            "ignore_files_with_gitattributes.lua": z.object({
+              name: z.literal("ignore_files_with_gitattributes.lua"),
+              type: z.literal("file"),
+            }),
+          }),
+        }),
         ripgrep: z.object({
           name: z.literal("ripgrep/"),
           type: z.literal("directory"),
@@ -126,6 +136,10 @@ export const MyTestDirectorySchema = z.object({
       name: z.literal("limited/"),
       type: z.literal("directory"),
       contents: z.object({
+        ".gitattributes": z.object({
+          name: z.literal(".gitattributes"),
+          type: z.literal("file"),
+        }),
         "dir with spaces": z.object({
           name: z.literal("dir with spaces/"),
           type: z.literal("directory"),
@@ -205,6 +219,8 @@ export const testDirectoryFiles = z.enum([
   "config-modifications/disable_buffer_words_source.lua",
   "config-modifications/don't_use_debug_mode.lua",
   "config-modifications/enable_customize_icon_highlight.lua",
+  "config-modifications/gitgrep/ignore_files_with_gitattributes.lua",
+  "config-modifications/gitgrep",
   "config-modifications/ripgrep/disable_project_root_fallback.lua",
   "config-modifications/ripgrep/set_ignore_paths.lua",
   "config-modifications/ripgrep/use_additional_paths.lua",
@@ -216,6 +232,7 @@ export const testDirectoryFiles = z.enum([
   "config-modifications/use_not_found_project_root.lua",
   "config-modifications",
   "initial-file.txt",
+  "limited/.gitattributes",
   "limited/dir with spaces/file with spaces.txt",
   "limited/dir with spaces/other file with spaces.txt",
   "limited/dir with spaces",

--- a/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_spec.cy.ts
@@ -144,6 +144,36 @@ describe("the GitGrepBackend", () => {
     })
   })
 
+  it("can use git pathspecs to customize the search", () => {
+    // git supports either tracked or untracked .gitattributes files to give
+    // custom attributes to files. blink-ripgrep can use these attributes to
+    // customize the search.
+    //
+    // - https://git-scm.com/docs/git-grep#Documentation/git-grep.txt-pathspec
+    // - https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-pathspec
+
+    cy.visit("/")
+    startNeovimWithGitBackend({
+      startupScriptModifications: [
+        "gitgrep/ignore_files_with_gitattributes.lua",
+      ],
+    }).then(() => {
+      cy.contains("If you see this text, Neovim is ready!")
+      createGitReposToLimitSearchScope()
+
+      cy.typeIntoTerminal("cc")
+
+      // find a match that has more than 5 lines of context
+      cy.typeIntoTerminal("someText")
+
+      // git-grep should have ignored files with the "blink-ripgrep-ignore"
+      // attribute. The files with that attribute should not show up in the
+      // search results.
+      cy.contains("SomeTextFromFile3")
+      cy.contains("someTextFromFile2").should("not.exist")
+    })
+  })
+
   it("can customize the icon in the completion results", () => {
     cy.visit("/")
     startNeovimWithGitBackend().then((nvim) => {
@@ -191,7 +221,7 @@ describe("the GitGrepBackend", () => {
     })
   })
 
-  it("highlights multiple matches on the same line correctly", () => {
+  it("highlights multiple matches on the same line", () => {
     // https://github.com/mikavilpas/blink-ripgrep.nvim/issues/228
     cy.visit("/")
     startNeovimWithGitBackend({

--- a/integration-tests/cypress/e2e/blink-ripgrep/utils/createGitReposToLimitSearchScope.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/utils/createGitReposToLimitSearchScope.ts
@@ -9,3 +9,14 @@ export function createGitReposToLimitSearchScope(): void {
     cwdRelative: "limited",
   })
 }
+
+export function createGitAttributesFile(): void {
+  cy.nvim_runBlockingShellCommand({
+    command: 'echo "*.log binary" > .gitattributes',
+    cwdRelative: ".",
+  })
+  cy.nvim_runBlockingShellCommand({
+    command: 'echo "*.log binary" > .gitattributes',
+    cwdRelative: "limited",
+  })
+}

--- a/integration-tests/test-environment/config-modifications/gitgrep/ignore_files_with_gitattributes.lua
+++ b/integration-tests/test-environment/config-modifications/gitgrep/ignore_files_with_gitattributes.lua
@@ -1,0 +1,16 @@
+-- git-grep can be configured to respect .gitattributes files for ignoring
+-- files. For more information, see:
+--
+-- https://git-scm.com/docs/git-grep#Documentation/git-grep.txt-pathspec
+-- https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-pathspec
+require("blink-ripgrep").setup({
+  backend = {
+    gitgrep = {
+      additional_gitgrep_options = {
+        -- exclude files marked with the 'blink-ripgrep-ignore' attribute in
+        -- .gitattributes
+        ":(exclude,attr:blink-ripgrep-ignore)",
+      },
+    },
+  },
+})

--- a/integration-tests/test-environment/limited/.gitattributes
+++ b/integration-tests/test-environment/limited/.gitattributes
@@ -1,0 +1,5 @@
+# ignore the following from blink-ripgrep by giving them a specific attribute
+# that we then ignore in the git grep command.
+#
+# The name of the attribute does not matter and can be chosen by the user.
+subproject/file2.lua blink-ripgrep-ignore

--- a/lua/blink-ripgrep/backends/git_grep/git_grep.lua
+++ b/lua/blink-ripgrep/backends/git_grep/git_grep.lua
@@ -40,7 +40,7 @@ function GitGrepBackend:get_matches(prefix, _, resolve)
     require("blink-ripgrep.backends.git_grep.gitgrep_command")
 
   local cwd = assert(vim.uv.cwd())
-  local cmd = command_module.get_command(prefix)
+  local cmd = command_module.get_command(prefix, self.config)
 
   if cmd == nil then
     if self.config.debug then

--- a/lua/blink-ripgrep/backends/git_grep/gitgrep_command.lua
+++ b/lua/blink-ripgrep/backends/git_grep/gitgrep_command.lua
@@ -5,9 +5,10 @@ GitgrepCommand.__index = GitgrepCommand
 
 --- Constructor.
 ---@param prefix string
+---@param config blink-ripgrep.Options
 ---@return blink-ripgrep.GitgrepCommand | nil, string? # The command to run, or an error message.
 ---@nodiscard
-function GitgrepCommand.get_command(prefix)
+function GitgrepCommand.get_command(prefix, config)
   local cmd = {
     "git",
     "grep",
@@ -18,16 +19,24 @@ function GitgrepCommand.get_command(prefix)
     "--column",
     -- ignore binary files
     "-I",
+    -- Match the pattern only at word boundary (either begin at the beginning
+    -- of a line, or preceded by a non-word character; end at the end of a line
+    -- or followed by a non-word character).
     "--word-regexp",
     -- use a null byte as the separator. This avoids issues with whitespace
     -- being padded in the line and column number output.
     "--null",
     "--recurse-submodules",
-    "--",
     prefix .. "[\\w_-]+",
   }
 
-  -- TODO support additional options to git grep
+  if
+    config.backend.gitgrep and config.backend.gitgrep.additional_gitgrep_options
+  then
+    for _, opt in ipairs(config.backend.gitgrep.additional_gitgrep_options) do
+      table.insert(cmd, opt)
+    end
+  end
 
   local command = setmetatable({
     command = cmd,
@@ -41,13 +50,13 @@ function GitgrepCommand:debugify_for_shell()
   -- print the command to :messages for hacky debugging, but don't show it
   -- in the ui so that it doesn't interrupt the user's work
   local debug_cmd = vim.deepcopy(self.command)
-  assert(#debug_cmd == 13, "unexpected command length")
+  assert(#debug_cmd >= 12, "unexpected command length " .. #debug_cmd)
 
   -- The pattern is not compatible with shell syntax, so escape it
   -- separately. The user should be able to copy paste it into their posix
   -- compatible terminal.
-  local pattern = debug_cmd[13]
-  debug_cmd[13] = "'" .. pattern .. "'"
+  local pattern = debug_cmd[12]
+  debug_cmd[12] = "'" .. pattern .. "'"
 
   local things = table.concat(debug_cmd, " ")
   vim.api.nvim_exec2("echomsg " .. vim.fn.string(things), {})

--- a/lua/blink-ripgrep/init.lua
+++ b/lua/blink-ripgrep/init.lua
@@ -24,6 +24,7 @@
 ---| "gitgrep" # Use git grep for searching. This is faster but only works in git repositories.
 
 ---@class blink-ripgrep.GitGrepBackendOptions
+---@field additional_gitgrep_options? string[] # Any extra options you want to give to git grep.
 
 ---@class blink-ripgrep.RipGrepBackendOptions
 ---@field ignore_paths? string[] # Absolute root paths where the rg command will not be executed. Usually you want to exclude paths using gitignore files or ripgrep specific ignore files, but this can be used to only ignore the paths in blink-ripgrep.nvim, maintaining the ability to use ripgrep for those paths on the command line. If you need to find out where the searches are executed, enable `debug` and look at `:messages`.


### PR DESCRIPTION
# feat: allow passing `additional_gitgrep_options` to git-grep backend

This can be used e.g. to ignore some files with a specific gitattributes
entry.

Documentation is available here:
https://github.com/mikavilpas/blink-ripgrep.nvim/blob/main/documentation/ignore-files-from-git-grep.md