### PR TITLE
chore: renovate keeps neovim plugins up to date

### DIFF
--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -145,8 +145,15 @@ local plugins = {
     end,
   },
 
-  { "folke/snacks.nvim" },
-  { "catppuccin/nvim", name = "catppuccin", priority = 1000 },
+  -- renovate: datasource=github-releases depName=folke/snacks.nvim
+  { "folke/snacks.nvim", version = "v2.28.0" },
+  {
+    "catppuccin/nvim",
+    name = "catppuccin",
+    priority = 1000,
+    -- renovate: datasource=github-releases depName=catppuccin/nvim
+    version = "v1.11.0",
+  },
 }
 require("lazy").setup({ spec = plugins })
 

--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
         "integration-tests/test-environment/.config/nvim/init.lua"
       ],
       "matchStrings": [
-        "--\\s*renovate:\\s*datasource=github-releases\\s+depName=(?<depName>\\S+)\\s*[\\r\\n]+[^=]+=\\s*\"?(?<currentValue>[^\",]+)\"?"
+        "-- renovate: datasource=github-releases depName=(?<depName>[^\\s]+)[\\s\\S]*?version\\s*=\\s*\"?(?<currentValue>[^\",]+)\"?"
       ]
     }
   ]


### PR DESCRIPTION
Also lock down the plugin versions to specific releases to make the build more reproducible.