### PR TITLE
refactor(lint): eslint ignores oxlint rules based on its config

### DIFF
--- a/integration-tests/eslint.config.mjs
+++ b/integration-tests/eslint.config.mjs
@@ -89,7 +89,7 @@ export default tseslint.config(
     },
   },
 
-  ...oxlint.configs["flat/recommended"],
+  ...oxlint.buildFromOxlintConfigFile("./.oxlintrc.json"),
   // should be the last item
   eslintConfigPrettier,
 )


### PR DESCRIPTION
https://www.npmjs.com/package/eslint-plugin-oxlint#detect-rules-from-oxlintrcjson

> If you are using flat configuration (eslint >= 9.0), you can use the
> following config:
>
> ```ts
> // eslint.config.js
> import oxlint from 'eslint-plugin-oxlint';
> export default [
>   ..., // other plugins
>   ...oxlint.buildFromOxlintConfigFile('./.oxlintrc.json'),
> ];
> ```