### PR TITLE
test: work around match conflict in tests

### DIFF
--- a/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_spec.cy.ts
@@ -170,7 +170,7 @@ describe("the GitGrepBackend", () => {
       // search results.
       cy.contains("SomeTextFromFile3")
       cy.contains("someTextFromFile2").should("not.exist")
-      cy.contains("someTextFromIgnoredDir").should("not.exist")
+      cy.contains("myTextFromIgnoredDir").should("not.exist")
     })
   })
 

--- a/integration-tests/test-environment/limited/subproject/ignored-dir/file.lua
+++ b/integration-tests/test-environment/limited/subproject/ignored-dir/file.lua
@@ -1,3 +1,3 @@
--- someTextFromIgnoredDir
+-- myTextFromIgnoredDir
 --
 -- the text in this file should be ignored because it's in an ignored directory


### PR DESCRIPTION
# test: work around match conflict in tests

**Issue:**

Many tests search for the arbitrarily chosen string `someTextFromFile2`
and `SomeTextFromFile3` to verify that search results work.

However, in
https://github.com/mikavilpas/blink-ripgrep.nvim/commit/e6705fcfccc71636f93f7417296f6831303c30ac
some text was added that also begins with `some`. Because ripgrep does
not guarantee the order of the results, now 3 search results are coming
up instead of 2, causing test failures because the expected result is no
longer automatically selected by default.

**Solution:**

Work around the issue by making the text in the ignored directory
different from the other test strings.
