### PR TITLE
test: run tests against stable and nightly blink

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,21 @@ on:
 
 jobs:
   build:
-    name: Run tests
+    name: "${{ matrix.neovim.name }} / ${{ matrix.blink.name }}"
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
-        neovim_version: ["nightly", "stable"]
+        neovim:
+          - name: nvim-stable
+            version: stable
+          - name: nvim-nightly
+            version: nightly
+        blink:
+          - name: blink-stable
+            appname: nvim
+          - name: blink-nightly
+            appname: nvim_blink_nightly
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -39,7 +49,7 @@ jobs:
       - name: Run lua tests
         uses: nvim-neorocks/nvim-busted-action@bbcfe82d35b8fb4660ef6ed4124e1fd9cef4688b # v1.2.0
         with:
-          nvim_version: ${{ matrix.neovim_version }}
+          nvim_version: ${{ matrix.neovim.version }}
           luarocks_version: "3.11.1"
 
       # https://github.com/cypress-io/github-action?tab=readme-ov-file#pnpm-workspaces
@@ -58,6 +68,8 @@ jobs:
       # need to work around https://github.com/cypress-io/github-action/issues/1246
       - run: pnpm --filter integration-tests exec cypress install
       - name: Run end-to-end tests
+        env:
+          NVIM_APPNAME: ${{ matrix.blink.appname }}
         run: |
           rg --version
           pnpm tui run
@@ -67,7 +79,19 @@ jobs:
         # if: failure()
         if: failure()
         with:
-          name: cypress-screenshots
+          name:
+            cypress-screenshots-${{ matrix.neovim.name }}-${{ matrix.blink.name
+            }}
           path: integration-tests/cypress/screenshots
           if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
 
+  required-checks:
+    name: test-matrix-success
+    if: always()
+    needs:
+      - build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Aggregate matrix result
+        if: needs.build.result != 'success'
+        run: exit 1

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -21,3 +21,4 @@ jobs:
             # space separated
             https://github.com/folke/snacks.nvim
             https://github.com/Saghen/blink.cmp
+            https://github.com/Saghen/blink.lib

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -46,6 +46,20 @@ export const MyTestDirectorySchema = z.object({
             }),
           }),
         }),
+        nvim_blink_nightly: z.object({
+          name: z.literal("nvim_blink_nightly/"),
+          type: z.literal("directory"),
+          contents: z.object({
+            "init.lua": z.object({
+              name: z.literal("init.lua"),
+              type: z.literal("file"),
+            }),
+            "prepare.lua": z.object({
+              name: z.literal("prepare.lua"),
+              type: z.literal("file"),
+            }),
+          }),
+        }),
       }),
     }),
     "additional-words-dir": z.object({
@@ -230,6 +244,9 @@ export const testDirectoryFiles = z.enum([
   ".config/nvim/init.lua",
   ".config/nvim/prepare.lua",
   ".config/nvim",
+  ".config/nvim_blink_nightly/init.lua",
+  ".config/nvim_blink_nightly/prepare.lua",
+  ".config/nvim_blink_nightly",
   ".config",
   "additional-words-dir/words.txt",
   "additional-words-dir",
@@ -271,4 +288,4 @@ export const testDirectoryFiles = z.enum([
   ".",
 ])
 export type MyTestDirectoryFile = z.infer<typeof testDirectoryFiles>
-export type MyNeovimAppName = "nvim"
+export type MyNeovimAppName = "nvim" | "nvim_blink_nightly"

--- a/integration-tests/cypress.config.ts
+++ b/integration-tests/cypress.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from "cypress"
 
+const nvimAppName = process.env.NVIM_APPNAME ?? "nvim"
+
 export default defineConfig({
   allowCypressEnv: false,
+  expose: {
+    NVIM_APPNAME: nvimAppName,
+  },
   e2e: {
     baseUrl: "http://localhost:3000",
     experimentalRunAllSpecs: true,

--- a/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_or_ripgrep_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_or_ripgrep_spec.cy.ts
@@ -1,5 +1,6 @@
 import type { NeovimContext } from "../../support/tui-sandbox"
 import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope"
+import { startNeovim } from "./utils/startNeovim"
 import { verifyCorrectBackendWasUsedInTest } from "./utils/verifyGitGrepBackendWasUsedInTest"
 
 type NeovimArguments = Parameters<typeof cy.startNeovim>[0]
@@ -16,7 +17,7 @@ function startNeovimWithThisBackend(
   }
 
   assert(options.startupScriptModifications.includes(backend))
-  return cy.startNeovim(options)
+  return startNeovim(options)
 }
 
 describe("the GitGrepOrRipgrepBackend", () => {

--- a/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_spec.cy.ts
@@ -9,6 +9,7 @@ import {
   textIsVisibleWithColor,
 } from "@tui-sandbox/library"
 import { textIsVisibleWithColors } from "./utils/color-utils"
+import { startNeovim } from "./utils/startNeovim.js"
 import { verifyCorrectBackendWasUsedInTest } from "./utils/verifyGitGrepBackendWasUsedInTest"
 
 export type CatppuccinRgb = (typeof flavors.macchiato.colors)["surface0"]["rgb"]
@@ -26,7 +27,7 @@ function startNeovimWithGitBackend(
   }
 
   assert(options.startupScriptModifications.includes(backend))
-  return cy.startNeovim(options)
+  return startNeovim(options)
 }
 
 describe("the GitGrepBackend", () => {

--- a/integration-tests/cypress/e2e/blink-ripgrep/backend_ripgrep_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/backend_ripgrep_spec.cy.ts
@@ -8,11 +8,12 @@ import { z } from "zod"
 import { assertMatchVisible } from "./utils/assertMatchVisible"
 import { textIsVisibleWithColors } from "./utils/color-utils"
 import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope"
+import { startNeovim } from "./utils/startNeovim"
 
 describe("the RipgrepBackend", () => {
   it("shows words in other files as suggestions", () => {
     cy.visit("/")
-    cy.startNeovim().then((nvim) => {
+    startNeovim().then((nvim) => {
       // wait until text on the start screen is visible
       cy.contains("If you see this text, Neovim is ready!")
       createGitReposToLimitSearchScope()
@@ -48,7 +49,7 @@ describe("the RipgrepBackend", () => {
     // ripgrep feature). However, the user may want to ignore some paths from
     // blink-ripgrep.nvim specifically. Here we test that feature.
     cy.visit("/")
-    cy.startNeovim({
+    startNeovim({
       filename: "limited/subproject/file1.lua",
       startupScriptModifications: ["ripgrep/set_ignore_paths.lua"],
     }).then((nvim) => {
@@ -95,7 +96,7 @@ describe("the RipgrepBackend", () => {
     // was found. Although we don't explicitly show all the matches in the
     // project, this can still be very useful.
     cy.visit("/")
-    cy.startNeovim().then(() => {
+    startNeovim().then(() => {
       cy.contains("If you see this text, Neovim is ready!")
       createGitReposToLimitSearchScope()
 
@@ -126,7 +127,7 @@ describe("the RipgrepBackend", () => {
     // the search. It works exactly like git does, and allows an intuitive way
     // to exclude files.
     cy.visit("/")
-    cy.startNeovim({
+    startNeovim({
       filename: "limited/dir with spaces/file with spaces.txt",
       startupScriptModifications: ["ripgrep/use_additional_paths.lua"],
     }).then(() => {
@@ -143,7 +144,7 @@ describe("the RipgrepBackend", () => {
 
   it("can customize the icon in the completion results", () => {
     cy.visit("/")
-    cy.startNeovim().then((nvim) => {
+    startNeovim().then((nvim) => {
       // wait until text on the start screen is visible
       cy.contains("If you see this text, Neovim is ready!")
       createGitReposToLimitSearchScope()
@@ -192,7 +193,7 @@ describe("the RipgrepBackend", () => {
   it("highlights multiple matches on the same line correctly", () => {
     // https://github.com/mikavilpas/blink-ripgrep.nvim/issues/228
     cy.visit("/")
-    cy.startNeovim({
+    startNeovim({
       startupScriptModifications: ["disable_buffer_words_source.lua"],
     }).then(() => {
       // wait until text on the start screen is visible
@@ -232,7 +233,7 @@ describe("the RipgrepBackend", () => {
 describe("in debug mode", () => {
   it("can execute the rg debug command in a shell", () => {
     cy.visit("/")
-    cy.startNeovim({
+    startNeovim({
       // also test that the plugin can handle spaces in the file path
       filename: "limited/dir with spaces/file with spaces.txt",
       startupScriptModifications: ["ripgrep/use_additional_paths.lua"],
@@ -287,7 +288,7 @@ describe("in debug mode", () => {
       return
     } else {
       cy.visit("/")
-      cy.startNeovim({}).then((nvim) => {
+      startNeovim({}).then((nvim) => {
         // wait until text on the start screen is visible
         cy.contains("If you see this text, Neovim is ready!")
         createGitReposToLimitSearchScope()

--- a/integration-tests/cypress/e2e/blink-ripgrep/debug-mode.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/debug-mode.cy.ts
@@ -1,4 +1,5 @@
 import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope"
+import { startNeovim } from "./utils/startNeovim"
 import { verifyCorrectBackendWasUsedInTest } from "./utils/verifyGitGrepBackendWasUsedInTest"
 
 describe("debug mode", () => {
@@ -8,7 +9,7 @@ describe("debug mode", () => {
     // https://github.com/mikavilpas/blink-ripgrep.nvim/issues/102
 
     cy.visit("/")
-    cy.startNeovim({}).then((nvim) => {
+    startNeovim({}).then((nvim) => {
       // wait until text on the start screen is visible
       cy.contains("If you see this text, Neovim is ready!")
       createGitReposToLimitSearchScope()
@@ -41,7 +42,7 @@ describe("debug mode", () => {
     // https://github.com/mikavilpas/blink-ripgrep.nvim/issues/102
 
     cy.visit("/")
-    cy.startNeovim({
+    startNeovim({
       startupScriptModifications: ["use_gitgrep_backend.lua"],
     }).then((nvim) => {
       // wait until text on the start screen is visible

--- a/integration-tests/cypress/e2e/blink-ripgrep/health_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/health_spec.cy.ts
@@ -1,7 +1,9 @@
+import { startNeovim } from "./utils/startNeovim"
+
 describe("the healthcheck", () => {
   it("does not show any errors when ripgrep is installed", () => {
     cy.visit("/")
-    cy.startNeovim().then(() => {
+    startNeovim().then(() => {
       // wait until text on the start screen is visible
       cy.contains("If you see this text, Neovim is ready!")
 

--- a/integration-tests/cypress/e2e/blink-ripgrep/searching-inside-projects.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/searching-inside-projects.cy.ts
@@ -6,6 +6,7 @@ import {
 } from "@tui-sandbox/library"
 import type { MyTestDirectoryFile } from "../../../MyTestDirectory"
 import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope"
+import { startNeovim } from "./utils/startNeovim"
 
 describe("searching inside projects with the RipgrepBackend", () => {
   // NOTE: the tests setup git repositories in the test environment using
@@ -15,7 +16,7 @@ describe("searching inside projects with the RipgrepBackend", () => {
   // file.
   it("descends into subprojects", () => {
     cy.visit("/")
-    cy.startNeovim({ filename: "limited/main-project-file.lua" }).then(() => {
+    startNeovim({ filename: "limited/main-project-file.lua" }).then(() => {
       // when completing from a file in a superproject, the search may descend
       // to subprojects
       cy.contains("this text is from main-project-file")
@@ -30,7 +31,7 @@ describe("searching inside projects with the RipgrepBackend", () => {
 
   it("limits the search to the nearest .git directory", () => {
     cy.visit("/")
-    cy.startNeovim({ filename: "limited/subproject/file1.lua" }).then(() => {
+    startNeovim({ filename: "limited/subproject/file1.lua" }).then(() => {
       // when opening a file from a subproject, the search should be limited to
       // the nearest .git directory (only the files in the same project should
       // be searched)
@@ -46,7 +47,7 @@ describe("searching inside projects with the RipgrepBackend", () => {
 
   it("does not search if the project root is not found", () => {
     cy.visit("/")
-    cy.startNeovim({
+    startNeovim({
       filename: "limited/subproject/file1.lua",
       startupScriptModifications: [
         "use_not_found_project_root.lua",
@@ -99,7 +100,7 @@ describe("searching inside projects with the RipgrepBackend", () => {
   describe("custom ripgrep options", () => {
     it("allows using a custom search_casing when searching", () => {
       cy.visit("/")
-      cy.startNeovim({
+      startNeovim({
         filename: "limited/subproject/file1.lua",
       }).then((nvim) => {
         cy.contains("This is text from file1.lua")
@@ -131,7 +132,7 @@ describe("searching inside projects with the RipgrepBackend", () => {
 
   it("can highlight the match in the documentation window", () => {
     cy.visit("/")
-    cy.startNeovim({ filename: "limited/subproject/file1.lua" }).then(() => {
+    startNeovim({ filename: "limited/subproject/file1.lua" }).then(() => {
       // When a match has been found in a file in the project, the
       // documentation window should show a preview of the match context (lines
       // around the match), and highlight the part where the match was found.
@@ -156,7 +157,7 @@ describe("searching inside projects with the RipgrepBackend", () => {
   describe("regex based syntax highlighting", () => {
     it("can highlight file types that don't have a treesitter parser installed", () => {
       cy.visit("/")
-      cy.startNeovim({ filename: "limited/subproject/file1.lua" }).then(() => {
+      startNeovim({ filename: "limited/subproject/file1.lua" }).then(() => {
         // when opening a file from a subproject, the search should be limited to
         // the nearest .git directory (only the files in the same project should
         // be searched)
@@ -194,7 +195,7 @@ describe("searching inside projects with the RipgrepBackend", () => {
     it("can disable regex based highlighting altogether", () => {
       // This is a regression test for https://github.com/mikavilpas/blink-ripgrep.nvim/issues/598
       cy.visit("/")
-      cy.startNeovim({
+      startNeovim({
         filename: "limited/subproject/file1.lua",
         startupScriptModifications: [
           "disable_highlighting_fallback_to_regex.lua",
@@ -225,7 +226,7 @@ describe("searching inside projects with the RipgrepBackend", () => {
       // the search. It works exactly like git does, and allows an intuitive way
       // to exclude files.
       cy.visit("/")
-      cy.startNeovim({
+      startNeovim({
         filename: "limited/dir with spaces/file with spaces.txt",
       }).then((nvim) => {
         // wait until text on the start screen is visible

--- a/integration-tests/cypress/e2e/blink-ripgrep/toggling.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/toggling.cy.ts
@@ -1,13 +1,14 @@
 import { flavors } from "@catppuccin/palette"
 import { rgbify, textIsVisibleWithColor } from "@tui-sandbox/library"
 import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope"
+import { startNeovim } from "./utils/startNeovim"
 
 describe("toggling features on/off", () => {
   // Some features can be toggled on/off without restarting Neovim. This can be
   // useful to combat performance issues, for example.
   it("can toggle the plugin on/off in blink completions", () => {
     cy.visit("/")
-    cy.startNeovim({
+    startNeovim({
       filename: "limited/main-project-file.lua",
     }).then((nvim) => {
       // when completing from a file in a superproject, the search may descend
@@ -58,7 +59,7 @@ describe("toggling features on/off", () => {
 
   it("can toggle debug mode on/off", () => {
     cy.visit("/")
-    cy.startNeovim({
+    startNeovim({
       filename: "limited/main-project-file.lua",
     }).then((nvim) => {
       // when completing from a file in a superproject, the search may descend

--- a/integration-tests/cypress/e2e/blink-ripgrep/utils/startNeovim.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/utils/startNeovim.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+import type { MyNeovimAppName } from "../../../../MyTestDirectory"
+import type {
+  MyStartNeovimServerArguments,
+  NeovimContext,
+} from "../../../support/tui-sandbox"
+
+const nvimAppNameSchema = z.enum([
+  "nvim",
+  "nvim_blink_nightly",
+] satisfies MyNeovimAppName[])
+
+export function startNeovim(
+  opts: MyStartNeovimServerArguments = {},
+): Cypress.Chainable<NeovimContext> {
+  const appname = nvimAppNameSchema.parse(Cypress.expose("NVIM_APPNAME"))
+  return cy.startNeovim({ NVIM_APPNAME: appname, ...opts })
+}

--- a/integration-tests/cypress/support/tui-sandbox.ts
+++ b/integration-tests/cypress/support/tui-sandbox.ts
@@ -8,6 +8,7 @@ import type {
   GenericTerminalBrowserApi,
 } from "@tui-sandbox/library/browser/neovim-client.js"
 import type { MyNeovimConfigModification } from "@tui-sandbox/library/client"
+import { drawTextBox } from "@tui-sandbox/library/client"
 import type {
   AllKeys,
   BlockingCommandClientInput,
@@ -138,6 +139,7 @@ Cypress.Commands.add(
         startArguments as StartNeovimGenericArguments,
       )
       testNeovim = underlyingNeovim
+      testEnvironmentPath = underlyingNeovim.dir.testEnvironmentPath
 
       // wrap everything so that Cypress can await all the commands
       Cypress.Commands.addAll({
@@ -209,6 +211,8 @@ Cypress.Commands.add(
           } satisfies AllKeys<BrowserTerminalSettings>,
         })
 
+      testEnvironmentPath = terminal.dir.testEnvironmentPath
+
       Cypress.Commands.addAll({
         terminal_runBlockingShellCommand: terminal.runBlockingShellCommand,
       })
@@ -245,6 +249,7 @@ Cypress.Commands.add(
 )
 
 let testNeovim: GenericNeovimBrowserApi | undefined
+let testEnvironmentPath: string | undefined
 
 before(function () {
   // disable Cypress's default behavior of logging all XMLHttpRequests and
@@ -303,6 +308,77 @@ declare global {
   }
 }
 
-afterEach(async () => {
+afterEach(function () {
   testNeovim = undefined
+
+  if (testEnvironmentPath) {
+    const testErr = this.currentTest?.err
+    const terminalContent = getTerminalContent() ?? ""
+
+    const snapshot = {
+      testTitle: this.currentTest?.fullTitle() ?? "unknown",
+      testState: this.currentTest?.state ?? "unknown",
+      terminalContent,
+      error: testErr?.message ?? null,
+      timestamp: new Date().toISOString(),
+    }
+
+    // Write to testdirs/ which is already gitignored for all tui-sandbox consumers.
+    // YAML is used so that multiline terminal content is human/AI-readable
+    // without escape sequences.
+    const snapshotPath = `${testEnvironmentPath}/testdirs/.terminal-snapshot.yaml`
+    const indentedContent = snapshot.terminalContent
+      .split("\n")
+      .map((line) => `  ${line}`)
+      .join("\n")
+    const testFile = this.currentTest?.file ?? "unknown"
+    const yaml = [
+      `testTitle: ${JSON.stringify(snapshot.testTitle)}`,
+      `testFile: ${JSON.stringify(testFile)}`,
+      `testState: ${snapshot.testState}`,
+      `error: ${snapshot.error ? JSON.stringify(snapshot.error) : "null"}`,
+      `timestamp: ${JSON.stringify(snapshot.timestamp)}`,
+      `terminalContent: |`,
+      indentedContent,
+    ].join("\n")
+    cy.writeFile(snapshotPath, yaml, { log: false })
+  }
+})
+
+/** Read the current terminal content from the xterm.js DOM. */
+function getTerminalContent(): string | undefined {
+  const rows = Cypress.$("div.xterm-rows > div")
+  if (rows.length === 0) return undefined
+
+  const lines: string[] = []
+  rows.each((_, row) => {
+    lines.push(Cypress.$(row).text())
+  })
+
+  // Trim trailing empty lines for readability
+  while (lines.length > 0 && lines[lines.length - 1]?.trim() === "") {
+    lines.pop()
+  }
+
+  return lines.length > 0 ? lines.join("\n") : undefined
+}
+
+// On test failure in headless mode (cypress run / CI), append the terminal
+// buffer contents to the error message so it appears in logs. In interactive
+// mode (cypress open), the terminal is already visible on screen so this
+// would just add noise.
+//
+// Registered via beforeEach + cy.on (per-test) so that tests can override
+// with their own cy.on('fail') handler to swallow expected errors.
+beforeEach(function () {
+  cy.on("fail", (err: Error) => {
+    if (!Cypress.config("isInteractive")) {
+      const content = getTerminalContent()
+      if (content) {
+        err.message += `\n\n${drawTextBox("Terminal content at failure", content)}`
+      }
+    }
+
+    throw err
+  })
 })

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -7,7 +7,9 @@
     "build": "tsc",
     "cy:open": "cypress open --e2e",
     "cy:run": "pnpm tui neovim prepare && concurrently --success command-cypress --kill-others --names 'app,cypress' --prefix-colors 'blue,yellow' 'pnpm tui start' 'wait-on --timeout 60000 http://127.0.0.1:3000 && npx cypress run --quiet'",
+    "cy:run:nightly": "NVIM_APPNAME=nvim_blink_nightly pnpm cy:run",
     "dev": "pnpm tui neovim prepare && concurrently --kill-others --names 'app,cypress' --prefix-colors 'blue,yellow' 'pnpm tui start' 'pnpm cy:open --e2e --browser=electron > /dev/null 2>&1'",
+    "dev:nightly": "NVIM_APPNAME=nvim_blink_nightly pnpm dev",
     "lint": "pnpx oxlint --type-aware --deny-warnings --report-unused-disable-directives && eslint --max-warnings=0 ."
   },
   "devDependencies": {

--- a/integration-tests/test-environment/.config/nvim_blink_nightly/init.lua
+++ b/integration-tests/test-environment/.config/nvim_blink_nightly/init.lua
@@ -1,0 +1,164 @@
+-- renovate: datasource=github-releases depName=folke/lazy.nvim
+local lazy_version = "v11.17.5"
+
+-- Bootstrap lazy.nvim
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not vim.loop.fs_stat(lazypath) then
+  local lazyrepo = "https://github.com/folke/lazy.nvim.git"
+  local out = vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "--branch=" .. lazy_version,
+    lazyrepo,
+    lazypath,
+  })
+  if vim.v.shell_error ~= 0 then
+    vim.api.nvim_echo({
+      { "Failed to clone lazy.nvim:\n", "ErrorMsg" },
+      { out, "WarningMsg" },
+      { "\nPress any key to exit..." },
+    }, true, {})
+    vim.fn.getchar()
+    os.exit(1)
+  end
+end
+vim.opt.rtp:prepend(lazypath)
+
+-- Make sure to setup `mapleader` and `maplocalleader` before
+-- loading lazy.nvim so that mappings are correct.
+-- This is also a good place to setup other settings (vim.opt)
+vim.g.mapleader = " "
+vim.g.maplocalleader = " "
+vim.o.swapfile = false
+
+local config_dir =
+  assert(os.getenv("XDG_CONFIG_HOME"), "XDG_CONFIG_HOME not set")
+local repo_root =
+  vim.fs.abspath(vim.fs.joinpath(config_dir, "..", "..", "..", "..", ".."))
+
+-- install the following plugins
+---@type LazySpec
+local plugins = {
+  {
+    "saghen/blink.cmp",
+    dependencies = {
+      "saghen/blink.lib",
+    },
+    -- dir = "/Users/mikavilpas/git/blink.cmp/",
+
+    event = "VeryLazy",
+    -- renovate: datasource=git-refs-master packageName=https://github.com/nvim-telescope/telescope.nvim
+    commit = "e1dbca9ea1d8",
+
+    -- to (locally) track nightly builds, use the following:
+    -- version = false,
+
+    -- to (locally) track nightly builds, use the following:
+    -- dir = "/Users/mikavilpas/git/blink.cmp/",
+    -- build = "cargo build --release",
+
+    ---@module 'blink.cmp'
+    ---@type blink.cmp.Config
+    opts = {
+      sources = {
+        default = {
+          "buffer",
+          "ripgrep",
+        },
+        providers = {
+          ripgrep = {
+            module = "blink-ripgrep",
+            name = "Ripgrep",
+            transform_items = function(_, items)
+              for _, item in ipairs(items) do
+                item.labelDetails = {
+                  description = "(rg)",
+                }
+              end
+              return items
+            end,
+            ---@type blink-ripgrep.Options
+            opts = {
+              debug = true,
+              toggles = {
+                on_off = "<leader>tg",
+                debug = "<leader>td",
+              },
+              backend = {
+                customize_icon_highlight = false,
+              },
+            },
+          },
+        },
+      },
+      fuzzy = {
+        implementation = "lua",
+      },
+      ---@diagnostic disable-next-line: missing-fields
+      completion = {
+        ---@diagnostic disable-next-line: missing-fields
+        documentation = {
+          ---@diagnostic disable-next-line: missing-fields
+          window = {
+            desired_min_height = 30,
+          },
+          auto_show = true,
+          auto_show_delay_ms = 0,
+        },
+        ---@diagnostic disable-next-line: missing-fields
+        menu = {
+          max_height = 25,
+
+          draw = {
+            columns = {
+              { "kind_icon", "label", "label_description", gap = 1 },
+              { "kind", gap = 6 },
+              { "source_name", gap = 1 },
+            },
+          },
+        },
+      },
+      keymap = {
+        ["<c-g>"] = {
+          function()
+            require("blink-cmp").show({ providers = { "ripgrep" } })
+          end,
+        },
+      },
+    },
+  },
+  {
+    "mikavilpas/blink-ripgrep.nvim",
+    -- for tests, always use the code from this repository
+    dir = repo_root,
+    config = function()
+      -- customize the search highlighting (Search)
+      local colors = require("catppuccin.palettes.macchiato")
+      vim.api.nvim_set_hl(
+        0,
+        "BlinkRipgrepMatch",
+        { fg = colors.base, bg = colors.mauve }
+      )
+
+      vim.api.nvim_set_hl(
+        0,
+        "BlinkRipgrepSearchPrefix",
+        { fg = colors.base, bg = colors.flamingo }
+      )
+    end,
+  },
+
+  -- renovate: datasource=github-releases depName=folke/snacks.nvim
+  { "folke/snacks.nvim", version = "v2.31.0" },
+  {
+    "catppuccin/nvim",
+    name = "catppuccin",
+    priority = 1000,
+    -- renovate: datasource=github-releases depName=catppuccin/nvim
+    version = "v2.0.0",
+  },
+}
+require("lazy").setup({ spec = plugins })
+
+vim.cmd.colorscheme("catppuccin-macchiato")

--- a/integration-tests/test-environment/.config/nvim_blink_nightly/prepare.lua
+++ b/integration-tests/test-environment/.config/nvim_blink_nightly/prepare.lua
@@ -1,0 +1,9 @@
+-- This file defines how to set up Neovim's plugins and external applications
+-- such as LSP servers and formatters.
+--
+-- They can be slow to install, which would make the tests slow (and they might
+-- be flaky because of this). This is why this file can be executed before
+-- starting the test run.
+
+-- make sure the dependencies defined in ./init.lua are installed
+vim.cmd("Lazy! sync")

--- a/integration-tests/tsconfig.json
+++ b/integration-tests/tsconfig.json
@@ -24,6 +24,7 @@
     "./client",
     "./server",
     "./cypress",
-    "./eslint.config.mjs"
+    "./eslint.config.mjs",
+    "./tui-sandbox.config.ts"
   ]
 }

--- a/integration-tests/tui-sandbox.config.ts
+++ b/integration-tests/tui-sandbox.config.ts
@@ -1,0 +1,8 @@
+import { createDefaultConfig } from "@tui-sandbox/library/dist/src/server/config.js"
+import type { TestServerConfig } from "@tui-sandbox/library/dist/src/server/index.js"
+
+export const config: TestServerConfig = createDefaultConfig(
+  process.cwd(),
+  process.env,
+)
+config.integrations.neovim.NVIM_APPNAMEs = ["nvim", "nvim_blink_nightly"]

--- a/lua/blink-ripgrep/backends/git_grep_or_ripgrep/git_grep_or_ripgrep.lua
+++ b/lua/blink-ripgrep/backends/git_grep_or_ripgrep/git_grep_or_ripgrep.lua
@@ -79,9 +79,13 @@ function GitGrepOrRipgrepBackend:get_matches(prefix, context, resolve)
 end
 
 ---@param cwd string
----@return blink.cmp.Task
+---@return blink.lib.Task
 function GitGrepOrRipgrepBackend:is_git_available(cwd)
-  local task = require("blink.cmp.lib.async").task
+  -- blink.cmp v2 moved the task module to the separate blink.lib plugin.
+  local ok, task = pcall(require, "blink.lib.task")
+  if not ok then
+    task = require("blink.cmp.lib.async").task
+  end
 
   ---@type vim.SystemObj
   local job

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "license": "MIT",
   "scripts": {
     "cy:run": "pnpm --filter ./integration-tests/ cy:run",
+    "cy:run:nightly": "pnpm --filter ./integration-tests/ cy:run:nightly",
     "dev": "pnpm --filter ./integration-tests/ dev",
+    "dev:nightly": "pnpm --filter ./integration-tests/ dev:nightly",
     "lint": "pnpm --filter ./integration-tests/ lint",
     "markdownlint": "rumdl check",
     "prettier": "prettier --check .",


### PR DESCRIPTION
# test: run tests against stable and nightly blink

**Issue:**

Nightly versions of blink.cmp may have issues that cannot be detected.

**Solution:**

Run all tests in a matrix that has

- one dimension for Neovim version (stable or nightly)
- one dimension for the blink.cmp version (stable or nightly)

Just like for stable blink, renovate (https://docs.renovatebot.com/) manages the version. For nightly blink, a commit id is tracked, and updated on Mondays only (configured [here](https://github.com/mikavilpas/mika-renovate/blob/dc2429b1d48f509c39f9c12dc6c7eac8ff81401f/default.json?plain=1#L11)).

I no longer use nightly blink, so fixes might not happen that quickly - contributions are welcome!

Fixes: https://github.com/mikavilpas/blink-ripgrep.nvim/issues/711

# fix: nightly-blink moved async Task to blink.lib plugin

# chore: commit tui-sandbox codegen

---

# Pull request stack

- 👉🏻 **[#712](https://github.com/mikavilpas/blink-ripgrep.nvim/pull/712)** | test: run tests against stable and nightly blink 👈🏻