### PR TITLE
test: pin all nightly versions correctly, and auto-update them weekly

### DIFF
--- a/integration-tests/cypress/support/tui-sandbox.ts
+++ b/integration-tests/cypress/support/tui-sandbox.ts
@@ -8,7 +8,10 @@ import type {
   GenericTerminalBrowserApi,
 } from "@tui-sandbox/library/browser/neovim-client.js"
 import type { MyNeovimConfigModification } from "@tui-sandbox/library/client"
-import { drawTextBox } from "@tui-sandbox/library/client"
+import {
+  drawTextBox,
+  extractTerminalContent,
+} from "@tui-sandbox/library/client"
 import type {
   AllKeys,
   BlockingCommandClientInput,
@@ -348,19 +351,8 @@ afterEach(function () {
 /** Read the current terminal content from the xterm.js DOM. */
 function getTerminalContent(): string | undefined {
   const rows = Cypress.$("div.xterm-rows > div")
-  if (rows.length === 0) return undefined
-
-  const lines: string[] = []
-  rows.each((_, row) => {
-    lines.push(Cypress.$(row).text())
-  })
-
-  // Trim trailing empty lines for readability
-  while (lines.length > 0 && lines[lines.length - 1]?.trim() === "") {
-    lines.pop()
-  }
-
-  return lines.length > 0 ? lines.join("\n") : undefined
+  const rowTexts = rows.toArray().map((row) => Cypress.$(row).text())
+  return extractTerminalContent(rowTexts)
 }
 
 // On test failure in headless mode (cypress run / CI), append the terminal

--- a/integration-tests/test-environment/.config/nvim_blink_nightly/init.lua
+++ b/integration-tests/test-environment/.config/nvim_blink_nightly/init.lua
@@ -43,7 +43,11 @@ local plugins = {
   {
     "saghen/blink.cmp",
     dependencies = {
-      "saghen/blink.lib",
+      {
+        "saghen/blink.lib",
+        -- renovate: datasource=git-refs packageName=https://github.com/saghen/blink.lib
+        commit = "796121278a414eb0b487d115786c603a764ac82a",
+      },
     },
 
     event = "VeryLazy",

--- a/integration-tests/test-environment/.config/nvim_blink_nightly/init.lua
+++ b/integration-tests/test-environment/.config/nvim_blink_nightly/init.lua
@@ -45,11 +45,10 @@ local plugins = {
     dependencies = {
       "saghen/blink.lib",
     },
-    -- dir = "/Users/mikavilpas/git/blink.cmp/",
 
     event = "VeryLazy",
-    -- renovate: datasource=git-refs-master packageName=https://github.com/nvim-telescope/telescope.nvim
-    commit = "506338434fec5ad19cb1f8d45bf92d66c4917393",
+    -- renovate: datasource=git-refs packageName=https://github.com/Saghen/blink.cmp
+    commit = "404ab55beb8b63d4c4be4bfd4e528441745b000a",
 
     -- to (locally) track nightly builds, use the following:
     -- version = false,


### PR DESCRIPTION
# test: lock down saghen/blink.lib version for nvim_blink_nightly tests

All the dependencies in the test runs need to be pinned to a specific commit/version for the tests to be reliable.

Renovate updates these weekly as defined in https://github.com/mikavilpas/mika-renovate/blob/2ffae5d74c51cf467244188e7a75993ff292723f/default.json#L11

# test: fix nvim_blink_nightly tracking telescope.nvim commits

Bad copy-paste from earlier.

# chore: commit tui-sandbox codegen

---

# Pull request stack

- 👉🏻 **[#730](https://github.com/mikavilpas/blink-ripgrep.nvim/pull/730)** | test: pin all nightly versions correctly, and auto-update them weekly 👈🏻