### PR TITLE
test: use import file extensions in integration tests

### DIFF
--- a/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_or_ripgrep_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_or_ripgrep_spec.cy.ts
@@ -1,7 +1,7 @@
-import type { NeovimContext } from "../../support/tui-sandbox"
-import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope"
-import { startNeovim } from "./utils/startNeovim"
-import { verifyCorrectBackendWasUsedInTest } from "./utils/verifyGitGrepBackendWasUsedInTest"
+import type { NeovimContext } from "../../support/tui-sandbox.js"
+import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope.js"
+import { startNeovim } from "./utils/startNeovim.js"
+import { verifyCorrectBackendWasUsedInTest } from "./utils/verifyGitGrepBackendWasUsedInTest.js"
 
 type NeovimArguments = Parameters<typeof cy.startNeovim>[0]
 

--- a/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/backend_gitgrep_spec.cy.ts
@@ -1,16 +1,16 @@
 import { flavors } from "@catppuccin/palette"
 import type { NeovimContext } from "../../support/tui-sandbox.js"
-import { assertMatchVisible } from "./utils/assertMatchVisible"
-import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope"
+import { assertMatchVisible } from "./utils/assertMatchVisible.js"
+import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope.js"
 
 import {
   rgbify,
   textIsVisibleWithBackgroundColor,
   textIsVisibleWithColor,
 } from "@tui-sandbox/library"
-import { textIsVisibleWithColors } from "./utils/color-utils"
+import { textIsVisibleWithColors } from "./utils/color-utils.js"
 import { startNeovim } from "./utils/startNeovim.js"
-import { verifyCorrectBackendWasUsedInTest } from "./utils/verifyGitGrepBackendWasUsedInTest"
+import { verifyCorrectBackendWasUsedInTest } from "./utils/verifyGitGrepBackendWasUsedInTest.js"
 
 export type CatppuccinRgb = (typeof flavors.macchiato.colors)["surface0"]["rgb"]
 

--- a/integration-tests/cypress/e2e/blink-ripgrep/backend_ripgrep_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/backend_ripgrep_spec.cy.ts
@@ -5,10 +5,10 @@ import {
   textIsVisibleWithColor,
 } from "@tui-sandbox/library"
 import { z } from "zod"
-import { assertMatchVisible } from "./utils/assertMatchVisible"
-import { textIsVisibleWithColors } from "./utils/color-utils"
-import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope"
-import { startNeovim } from "./utils/startNeovim"
+import { assertMatchVisible } from "./utils/assertMatchVisible.js"
+import { textIsVisibleWithColors } from "./utils/color-utils.js"
+import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope.js"
+import { startNeovim } from "./utils/startNeovim.js"
 
 describe("the RipgrepBackend", () => {
   it("shows words in other files as suggestions", () => {

--- a/integration-tests/cypress/e2e/blink-ripgrep/debug-mode.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/debug-mode.cy.ts
@@ -1,6 +1,6 @@
-import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope"
-import { startNeovim } from "./utils/startNeovim"
-import { verifyCorrectBackendWasUsedInTest } from "./utils/verifyGitGrepBackendWasUsedInTest"
+import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope.js"
+import { startNeovim } from "./utils/startNeovim.js"
+import { verifyCorrectBackendWasUsedInTest } from "./utils/verifyGitGrepBackendWasUsedInTest.js"
 
 describe("debug mode", () => {
   it("can clean up (kill) a previous rg search", () => {

--- a/integration-tests/cypress/e2e/blink-ripgrep/health_spec.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/health_spec.cy.ts
@@ -1,4 +1,4 @@
-import { startNeovim } from "./utils/startNeovim"
+import { startNeovim } from "./utils/startNeovim.js"
 
 describe("the healthcheck", () => {
   it("does not show any errors when ripgrep is installed", () => {

--- a/integration-tests/cypress/e2e/blink-ripgrep/searching-inside-projects.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/searching-inside-projects.cy.ts
@@ -4,9 +4,9 @@ import {
   textIsVisibleWithBackgroundColor,
   textIsVisibleWithColor,
 } from "@tui-sandbox/library"
-import type { MyTestDirectoryFile } from "../../../MyTestDirectory"
-import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope"
-import { startNeovim } from "./utils/startNeovim"
+import type { MyTestDirectoryFile } from "../../../MyTestDirectory.js"
+import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope.js"
+import { startNeovim } from "./utils/startNeovim.js"
 
 describe("searching inside projects with the RipgrepBackend", () => {
   // NOTE: the tests setup git repositories in the test environment using

--- a/integration-tests/cypress/e2e/blink-ripgrep/toggling.cy.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/toggling.cy.ts
@@ -1,7 +1,7 @@
 import { flavors } from "@catppuccin/palette"
 import { rgbify, textIsVisibleWithColor } from "@tui-sandbox/library"
-import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope"
-import { startNeovim } from "./utils/startNeovim"
+import { createGitReposToLimitSearchScope } from "./utils/createGitReposToLimitSearchScope.js"
+import { startNeovim } from "./utils/startNeovim.js"
 
 describe("toggling features on/off", () => {
   // Some features can be toggled on/off without restarting Neovim. This can be

--- a/integration-tests/cypress/e2e/blink-ripgrep/utils/startNeovim.ts
+++ b/integration-tests/cypress/e2e/blink-ripgrep/utils/startNeovim.ts
@@ -1,9 +1,9 @@
 import { z } from "zod"
-import type { MyNeovimAppName } from "../../../../MyTestDirectory"
+import type { MyNeovimAppName } from "../../../../MyTestDirectory.js"
 import type {
   MyStartNeovimServerArguments,
   NeovimContext,
-} from "../../../support/tui-sandbox"
+} from "../../../support/tui-sandbox.js"
 
 const nvimAppNameSchema = z.enum([
   "nvim",

--- a/integration-tests/cypress/support/e2e.ts
+++ b/integration-tests/cypress/support/e2e.ts
@@ -15,4 +15,4 @@
 
 // Import commands.js using ES2015 syntax:
 // oxlint-disable-next-line no-unassigned-import
-import "./tui-sandbox"
+import "./tui-sandbox.js"

--- a/integration-tests/cypress/support/tui-sandbox.ts
+++ b/integration-tests/cypress/support/tui-sandbox.ts
@@ -31,7 +31,7 @@ import type {
   MyNeovimAppName,
   MyTestDirectory,
   MyTestDirectoryFile,
-} from "../../MyTestDirectory"
+} from "../../MyTestDirectory.js"
 
 export type TerminalTestApplicationContext = {
   /** Types text into the terminal, making the terminal application receive the

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@catppuccin/palette": "1.8.0",
     "@eslint/js": "10.0.1",
-    "@tui-sandbox/library": "12.5.1",
+    "@tui-sandbox/library": "12.5.3",
     "@types/node": "24.12.2",
     "concurrently": "9.2.1",
     "cypress": "15.14.2",

--- a/integration-tests/tsconfig.json
+++ b/integration-tests/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "skipLibCheck": true,
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "target": "ESNext",
     "isolatedModules": true,
     "esModuleInterop": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 10.0.1
         version: 10.0.1(eslint@10.2.1)
       '@tui-sandbox/library':
-        specifier: 12.5.1
-        version: 12.5.1(cypress@15.14.2)(prettier@3.8.3)(type-fest@5.6.0)(typescript@5.9.3)(wait-on@9.0.5)(zod@4.4.1)
+        specifier: 12.5.3
+        version: 12.5.3(cypress@15.14.2)(prettier@3.8.3)(type-fest@5.6.0)(typescript@5.9.3)(wait-on@9.0.5)(zod@4.4.1)
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
@@ -484,21 +484,21 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@trpc/client@11.16.0':
-    resolution: {integrity: sha512-TxIzm7OoK3baKZ0XCbuMUbI3GhgjcbKHIc4nWVKaRpCRnbSh0T31BT6fTPYwtnA/Nur8pBCGqC2B4J5hEPiPFQ==}
+  '@trpc/client@11.17.0':
+    resolution: {integrity: sha512-KpJBFrbKTDeVCFv/3ckL1XBBH5Yssn8hethI/rUy7GIpTj+VzjtPjykDqJpzobuVOz+d26cXCSu1t4I6MYI5Zg==}
     hasBin: true
     peerDependencies:
-      '@trpc/server': 11.16.0
+      '@trpc/server': 11.17.0
       typescript: '>=5.7.2'
 
-  '@trpc/server@11.16.0':
-    resolution: {integrity: sha512-XgGuUMddrUTd04+za/WE5GFuZ1/YU9XQG0t3VL5WOIu2JspkOlq6k4RYEiqS6HSJt+S0RXaPdIoE2anIP/BBRQ==}
+  '@trpc/server@11.17.0':
+    resolution: {integrity: sha512-jbAOUe0PpUTCYqziyu+8vYXZdDXPudZgnEhWCQ2NjKnVEjfE93RqHTt1oycZJv/HNf51YlRXfEEwSIAbb161rw==}
     hasBin: true
     peerDependencies:
       typescript: '>=5.7.2'
 
-  '@tui-sandbox/library@12.5.1':
-    resolution: {integrity: sha512-O3G6C2RGVqCn4Eu2GtKiVOlGjOjlEoZf4ej1EzwojHzS7SzL0jkTICRobDP11Qt9IemTmV4SdhU8KZrY3ipvOg==}
+  '@tui-sandbox/library@12.5.3':
+    resolution: {integrity: sha512-a/DaWdWWkUsRMWyfMjk7GF8tAxG9p5Ix2436KnnS1iRii9E9tw4Bm6GFOkSB7dtvISi7ys6HNoSS2QV3szC0RQ==}
     engines: {node: '>=24.0.0'}
     hasBin: true
     peerDependencies:
@@ -1679,6 +1679,10 @@ packages:
     resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
     engines: {node: '>=20'}
 
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
@@ -2159,20 +2163,20 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@trpc/client@11.16.0(@trpc/server@11.16.0(typescript@5.9.3))(typescript@5.9.3)':
+  '@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@trpc/server': 11.16.0(typescript@5.9.3)
+      '@trpc/server': 11.17.0(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@trpc/server@11.16.0(typescript@5.9.3)':
+  '@trpc/server@11.17.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@tui-sandbox/library@12.5.1(cypress@15.14.2)(prettier@3.8.3)(type-fest@5.6.0)(typescript@5.9.3)(wait-on@9.0.5)(zod@4.4.1)':
+  '@tui-sandbox/library@12.5.3(cypress@15.14.2)(prettier@3.8.3)(type-fest@5.6.0)(typescript@5.9.3)(wait-on@9.0.5)(zod@4.4.1)':
     dependencies:
       '@catppuccin/palette': 1.8.0
-      '@trpc/client': 11.16.0(@trpc/server@11.16.0(typescript@5.9.3))(typescript@5.9.3)
-      '@trpc/server': 11.16.0(typescript@5.9.3)
+      '@trpc/client': 11.17.0(@trpc/server@11.17.0(typescript@5.9.3))(typescript@5.9.3)
+      '@trpc/server': 11.17.0(typescript@5.9.3)
       '@xterm/addon-clipboard': 0.2.0
       '@xterm/addon-fit': 0.11.0
       '@xterm/addon-unicode11': 0.9.0
@@ -2184,7 +2188,7 @@ snapshots:
       express: 5.2.1
       neovim: 5.4.0
       prettier: 3.8.3
-      string-width: 8.2.0
+      string-width: 8.2.1
       tsx: 4.21.0
       type-fest: 5.6.0
       typescript: 5.9.3
@@ -3462,6 +3466,11 @@ snapshots:
       strip-ansi: 7.2.0
 
   string-width@8.2.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.1:
     dependencies:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0


### PR DESCRIPTION
# test: use import file extensions in integration tests

---

# Pull request stack

- 👉🏻 **[#735](https://github.com/mikavilpas/blink-ripgrep.nvim/pull/735)** | test: use import file extensions in integration tests 👈🏻