### PR TITLE
chore(renovate): update blink nightly deps at the same time

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,19 @@
     {
       "matchDepNames": ["lua"],
       "allowedVersions": "<=5.1"
+    },
+    {
+      "description": [
+        "Update blink nightly deps at the same time.",
+        "This is needed because blink.cmp depends on blink.lib.",
+        "We want the latest versions and hope that they are compatible."
+      ],
+      "matchPackageNames": [
+        "https://github.com/saghen/blink.lib",
+        "https://github.com/Saghen/blink.cmp"
+      ],
+      "matchDatasources": ["git-refs"],
+      "groupName": "blink-nightly-deps"
     }
   ]
 }


### PR DESCRIPTION
# chore(renovate): update blink nightly deps at the same time

**Issue:**

Previously they were updated separately. This may cause blink.cmp to fail until blink.lib is updated.

Last time:

- [chore(deps): update https://github.com/saghen/blink.cmp digest to 80f5dd3](https://github.com/mikavilpas/blink-ripgrep.nvim/pull/736)
- [chore(deps): update https://github.com/saghen/blink.lib digest to f29d8ba](https://github.com/mikavilpas/blink-ripgrep.nvim/pull/737)

**Solution:**

Next time, avoid this by updating them at the same time. Have renovate group them together.

---

# Pull request stack

- 👉🏻 **[#749](https://github.com/mikavilpas/blink-ripgrep.nvim/pull/749)** | chore(renovate): update blink nightly deps at the same time 👈🏻