### PR TITLE
chore: move more formatting to use oxfmt

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -30,7 +30,7 @@ jobs:
           node-version-file: .nvmrc
           cache: "pnpm"
       - run: pnpm install
-      - run: pnpm oxfmt --check
+      - run: pnpm run format:check
 
   stylua:
     name: stylua

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:nightly": "pnpm --filter ./integration-tests/ dev:nightly",
     "lint": "pnpm --filter ./integration-tests/ lint",
     "markdownlint": "rumdl check",
-    "prettier": "prettier --check .",
+    "format:check": "oxfmt --check",
     "tui": "pnpm --filter ./integration-tests/ exec tui"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,14 +16,5 @@
   "devDependencies": {
     "oxfmt": "0.56.0"
   },
-  "packageManager": "pnpm@11.9.0",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "core-js",
-      "cypress",
-      "esbuild",
-      "node-pty",
-      "puppeteer"
-    ]
-  }
+  "packageManager": "pnpm@11.9.0"
 }


### PR DESCRIPTION
# chore: remove deprecated pnpm.onlyBuiltDependencies from package.json

# chore: move more formatting to use oxfmt

---

# Pull request stack

- 👉🏻 **[#869](https://github.com/mikavilpas/blink-ripgrep.nvim/pull/869)** | chore: move more formatting to use oxfmt 👈🏻