### PR TITLE
ci: no need to install yq as it comes preinstalled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,8 +55,6 @@ jobs:
               https://raw.githubusercontent.com/houseabsolute/ubi/master/bootstrap/bootstrap-ubi.sh |
               TARGET="$HOME/.local/bin" sh
 
-          ubi --project mikefarah/yq
-
           VERSION=$(yq '.tools."github:BurntSushi/ripgrep".version' mise.toml)
           ubi --project BurntSushi/ripgrep --tag "$VERSION" --exe rg
         env:


### PR DESCRIPTION
# ci: no need to install yq as it comes preinstalled

https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md already contains `yq 4.53.3`

---

# Pull request stack

- 👉🏻 **[#873](https://github.com/mikavilpas/blink-ripgrep.nvim/pull/873)** | ci: no need to install yq as it comes preinstalled 👈🏻