### PR TITLE
ci: run busted tests on a separate job for clarity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,53 @@ jobs:
         with:
           commit: ${{ env.NEOVIM_NIGHTLY_COMMIT }}
 
+  busted:
+    name: "Busted / ${{ matrix.neovim.name }}"
+    runs-on: ubuntu-24.04
+    needs: build-neovim-nightly
+    strategy:
+      fail-fast: false
+      matrix:
+        neovim:
+          - name: nvim-stable
+            version: stable
+          - name: nvim-nightly
+            version: nightly
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install tools with UBI
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          # make the tools available for subsequent steps
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
+          curl --silent --location \
+              https://raw.githubusercontent.com/houseabsolute/ubi/master/bootstrap/bootstrap-ubi.sh |
+              TARGET="$HOME/.local/bin" sh
+
+          VERSION=$(yq '.tools."github:BurntSushi/ripgrep".version' mise.toml)
+          ubi --project BurntSushi/ripgrep --tag "$VERSION" --exe rg
+
+      - name: Download pinned Neovim nightly
+        if: matrix.neovim.version == 'nightly'
+        uses: mikavilpas/neovim-action/restore-nightly@4f1c9a2235ee7428930602c0ba3e4f20377b61d8 # v3.3.0
+        with:
+          commit: ${{ env.NEOVIM_NIGHTLY_COMMIT }}
+
+      - name: Install stable Neovim
+        if: matrix.neovim.version == 'stable'
+        uses: rhysd/action-setup-vim@febef33995d6649302e9d88dda81e071b68f16a7 # v1.6.1
+        with:
+          neovim: true
+          version: stable
+
+      - name: Run tests
+        uses: mikavilpas/neovim-action/busted@4f1c9a2235ee7428930602c0ba3e4f20377b61d8 # v3.3.0
+
   build:
-    name: "${{ matrix.neovim.name }} / ${{ matrix.blink.name }}"
+    name: "e2e ${{ matrix.neovim.name }}, ${{ matrix.blink.name }}"
     runs-on: ubuntu-24.04
     needs: build-neovim-nightly
     strategy:
@@ -73,9 +118,6 @@ jobs:
           neovim: true
           version: stable
 
-      - name: Run tests
-        uses: mikavilpas/neovim-action/busted@4f1c9a2235ee7428930602c0ba3e4f20377b61d8 # v3.3.0
-
       # https://github.com/cypress-io/github-action?tab=readme-ov-file#pnpm-workspaces
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -113,6 +155,8 @@ jobs:
     name: test-matrix-success
     if: always()
     needs:
+      - build-neovim-nightly
+      - busted
       - build
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
# ci: run busted tests on a separate job for clarity

---

# Pull request stack

- 👉🏻 **[#874](https://github.com/mikavilpas/blink-ripgrep.nvim/pull/874)** | ci: run busted tests on a separate job for clarity 👈🏻