### PR TITLE
ci: fix incorrect ci gate only aggregating build job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,15 +151,24 @@ jobs:
           path: integration-tests/cypress/screenshots
           if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
 
-  required-checks:
-    name: test-matrix-success
-    if: always()
+  ci:
+    name: ci
+    if: ${{ always() }}
     needs:
       - build-neovim-nightly
       - busted
       - build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
-      - name: Aggregate matrix result
-        if: needs.build.result != 'success'
-        run: exit 1
+      - name: Verify all required jobs succeeded
+        if: >-
+          ${{
+            contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || contains(needs.*.result, 'skipped')
+          }}
+        run: |
+          echo "One or more required jobs did not succeed."
+          exit 1


### PR DESCRIPTION
# ci: fix incorrect ci gate only aggregating build job

---

# Pull request stack

- 👉🏻 **[#875](https://github.com/mikavilpas/blink-ripgrep.nvim/pull/875)** | ci: fix incorrect ci gate only aggregating build job 👈🏻